### PR TITLE
Expand puppetdb::cli profile for use by non-privileged users

### DIFF
--- a/manifests/puppetdb/cli.pp
+++ b/manifests/puppetdb/cli.pp
@@ -1,5 +1,9 @@
 class profiles::puppetdb::cli(
-  Variant[String, Array[String]] $server_urls
+  Variant[String, Array[String]] $server_urls,
+  Variant[String, Array[String]] $users       = 'root',
+  Optional[String]               $certificate = undef,
+  Optional[String]               $private_key = undef
+
 ) inherits ::profiles {
 
   include ::profiles::apt::updates
@@ -10,13 +14,11 @@ class profiles::puppetdb::cli(
     require => Profiles::Apt::Update['cultuurnet-tools']
   }
 
-  file { '/etc/puppetlabs/client-tools':
-    ensure  => 'directory'
-  }
-
-  file { 'puppetdb-cli-config':
-    ensure  => 'file',
-    path    => '/etc/puppetlabs/client-tools/puppetdb.conf',
-    content => template('profiles/puppetdb/cli.conf.erb')
+  [$users].flatten.each |$user| {
+    profiles::puppetdb::cli::config { $user:
+      server_urls => $server_urls,
+      certificate => $certificate,
+      private_key => $private_key
+    }
   }
 }

--- a/manifests/puppetdb/cli.pp
+++ b/manifests/puppetdb/cli.pp
@@ -7,6 +7,8 @@ class profiles::puppetdb::cli(
 ) inherits ::profiles {
 
   include ::profiles::apt::updates
+  include ::profiles::groups
+  include ::profiles::users
 
   realize Profiles::Apt::Update['cultuurnet-tools']
 
@@ -15,6 +17,13 @@ class profiles::puppetdb::cli(
   }
 
   [$users].flatten.each |$user| {
+    unless $user == 'root' {
+      realize Group[$user]
+      realize User[$user]
+
+      User[$user] -> Profiles::Puppetdb::Cli::Config[$user]
+    }
+
     profiles::puppetdb::cli::config { $user:
       server_urls => $server_urls,
       certificate => $certificate,

--- a/manifests/puppetdb/cli/config.pp
+++ b/manifests/puppetdb/cli/config.pp
@@ -1,0 +1,87 @@
+define profiles::puppetdb::cli::config (
+  Variant[String,Array[String]] $server_urls,
+  Optional[String]              $certificate = undef,
+  Optional[String]              $private_key = undef
+) {
+
+  include ::profiles
+
+  case $title {
+    'root':    {
+                 if ($certificate and $private_key) {
+                   $config_rootdir       = '/root/.puppetlabs'
+                   $certificate_filename = 'puppetdb-cli.crt'
+                   $private_key_filename = 'puppetdb-cli.key'
+                 } else {
+                   $config_rootdir = '/etc/puppetlabs'
+                   $certificate_filename = "${trusted['certname']}.pem"
+                   $private_key_filename = "${trusted['certname']}.pem"
+                 }
+               }
+    'jenkins': {
+                 if ($certificate and $private_key) {
+                   $config_rootdir = "/var/lib/${title}/.puppetlabs"
+                   $certificate_filename = 'puppetdb-cli.crt'
+                   $private_key_filename = 'puppetdb-cli.key'
+                 } else {
+                   fail("Profiles::Puppetdb::Cli::Config[${title}] expects a value for parameters 'certificate' and 'private_key'")
+                 }
+               }
+    default:   {
+                 if ($certificate and $private_key) {
+                   $config_rootdir = "/home/${title}/.puppetlabs"
+                   $certificate_filename = 'puppetdb-cli.crt'
+                   $private_key_filename = 'puppetdb-cli.key'
+                 } else {
+                   fail("Profiles::Puppetdb::Cli::Config[${title}] expects a value for parameters 'certificate' and 'private_key'")
+                 }
+               }
+  }
+
+  $ssl_dir = "${config_rootdir}/puppet/ssl"
+
+  if ($certificate and $private_key) {
+    [
+      $config_rootdir,
+      "${config_rootdir}/puppet",
+      "${config_rootdir}/puppet/ssl",
+      "${config_rootdir}/puppet/ssl/certs",
+      "${config_rootdir}/puppet/ssl/private_keys"
+    ].each |$directory| {
+      file { $directory:
+        ensure => 'directory',
+        owner  => $title
+      }
+    }
+
+    file { "${config_rootdir}/puppet/ssl/certs/ca.pem":
+      ensure => 'file',
+      owner  => $title,
+      source => '/etc/puppetlabs/puppet/ssl/certs/ca.pem'
+    }
+
+    file { "${config_rootdir}/puppet/ssl/certs/puppetdb-cli.crt":
+      ensure  => 'file',
+      owner   => $title,
+      content => $certificate
+    }
+
+    file { "${config_rootdir}/puppet/ssl/private_keys/puppetdb-cli.key":
+      ensure  => 'file',
+      owner   => $title,
+      content => $private_key
+    }
+  }
+
+  file { "${config_rootdir}/client-tools":
+    ensure => 'directory',
+    owner  => $title
+  }
+
+  file { "puppetdb-cli-config ${title}":
+    ensure  => 'file',
+    owner   => $title,
+    path    => "${config_rootdir}/client-tools/puppetdb.conf",
+    content => template('profiles/puppetdb/cli.conf.erb')
+  }
+}

--- a/manifests/puppetdb/cli/config.pp
+++ b/manifests/puppetdb/cli/config.pp
@@ -69,6 +69,7 @@ define profiles::puppetdb::cli::config (
     file { "${config_rootdir}/puppet/ssl/private_keys/puppetdb-cli.key":
       ensure  => 'file',
       owner   => $title,
+      mode    => '0400',
       content => $private_key
     }
   }

--- a/spec/classes/puppetdb/cli_spec.rb
+++ b/spec/classes/puppetdb/cli_spec.rb
@@ -43,6 +43,11 @@ describe 'profiles::puppetdb::cli' do
           'private_key' => 'def456'
         } }
 
+        it { is_expected.to_not contain_user('root') }
+
+        it { is_expected.to contain_group('jenkins') }
+        it { is_expected.to contain_user('jenkins') }
+
         it { is_expected.to contain_profiles__puppetdb__cli__config('root').with(
           'server_urls' => [ 'https://example.com:1234', 'https://example.com:5678'],
           'certificate' => 'abc123',
@@ -54,6 +59,8 @@ describe 'profiles::puppetdb::cli' do
           'certificate' => 'abc123',
           'private_key' => 'def456'
         ) }
+
+        it { is_expected.to contain_user('jenkins').that_comes_before('Profiles::Puppetdb::Cli::Config[jenkins]') }
       end
 
       context "without parameters" do

--- a/spec/defines/puppetdb/cli/config_spec.rb
+++ b/spec/defines/puppetdb/cli/config_spec.rb
@@ -41,7 +41,8 @@ RSpec.shared_examples "puppetdb-cli config file structure" do |user, rootdir|
 
   it { is_expected.to contain_file("#{rootdir}/puppet/ssl/private_keys/puppetdb-cli.key").with(
     'ensure' => 'file',
-    'owner'  => user
+    'owner'  => user,
+    'mode'   => '0400'
   ) }
 
   it { is_expected.to contain_file("#{rootdir}/client-tools").with(

--- a/spec/defines/puppetdb/cli/config_spec.rb
+++ b/spec/defines/puppetdb/cli/config_spec.rb
@@ -1,0 +1,199 @@
+require 'spec_helper'
+
+RSpec.shared_examples "puppetdb-cli config file structure" do |user, rootdir|
+  it { is_expected.to compile.with_all_deps }
+
+  it { is_expected.to contain_file(rootdir).with(
+    'ensure' => 'directory',
+    'owner'  => user
+  ) }
+
+  it { is_expected.to contain_file("#{rootdir}/puppet").with(
+    'ensure' => 'directory',
+    'owner'  => user
+  ) }
+
+  it { is_expected.to contain_file("#{rootdir}/puppet/ssl").with(
+    'ensure' => 'directory',
+    'owner'  => user
+  ) }
+
+  it { is_expected.to contain_file("#{rootdir}/puppet/ssl/certs").with(
+    'ensure' => 'directory',
+    'owner'  => user
+  ) }
+
+  it { is_expected.to contain_file("#{rootdir}/puppet/ssl/private_keys").with(
+    'ensure' => 'directory',
+    'owner'  => user
+  ) }
+
+  it { is_expected.to contain_file("#{rootdir}/puppet/ssl/certs/ca.pem").with(
+    'ensure' => 'file',
+    'owner'  => user,
+    'source' => '/etc/puppetlabs/puppet/ssl/certs/ca.pem'
+  ) }
+
+  it { is_expected.to contain_file("#{rootdir}/puppet/ssl/certs/puppetdb-cli.crt").with(
+    'ensure' => 'file',
+    'owner'  => user
+  ) }
+
+  it { is_expected.to contain_file("#{rootdir}/puppet/ssl/private_keys/puppetdb-cli.key").with(
+    'ensure' => 'file',
+    'owner'  => user
+  ) }
+
+  it { is_expected.to contain_file("#{rootdir}/client-tools").with(
+    'ensure' => 'directory',
+    'owner'  => user
+  ) }
+
+  it { is_expected.to contain_file("puppetdb-cli-config #{user}").with(
+    'ensure' => 'file',
+    'owner'  => user,
+    'path'   => "#{rootdir}/client-tools/puppetdb.conf"
+  ) }
+end
+
+describe 'profiles::puppetdb::cli::config' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      context "on node1.example.com with title root" do
+        let(:node) { 'node1.example.com' }
+        let(:title) { 'root' }
+
+        context "with server_urls => https://example.com:1234" do
+          let(:params) { {
+            'server_urls' => 'https://example.com:1234'
+          } }
+
+          it { is_expected.to compile.with_all_deps }
+
+          it { is_expected.to contain_profiles__puppetdb__cli__config('root').with(
+            'server_urls' => 'https://example.com:1234',
+            'certificate' => nil,
+            'private_key' => nil
+          ) }
+
+          it { is_expected.to_not contain_file('/etc/puppetlabs') }
+
+          it { is_expected.to contain_file('/etc/puppetlabs/client-tools').with('ensure' => 'directory') }
+
+          it { is_expected.to contain_file('puppetdb-cli-config root').with(
+            'ensure' => 'file',
+            'path'   => '/etc/puppetlabs/client-tools/puppetdb.conf',
+          ) }
+
+          it { is_expected.to contain_file('puppetdb-cli-config root').with_content(/"server_urls":\s*"https:\/\/example.com:1234"/) }
+          it { is_expected.to contain_file('puppetdb-cli-config root').with_content(/"cacert":\s*"\/etc\/puppetlabs\/puppet\/ssl\/certs\/ca.pem"/) }
+          it { is_expected.to contain_file('puppetdb-cli-config root').with_content(/"cert":\s*"\/etc\/puppetlabs\/puppet\/ssl\/certs\/node1.example.com.pem"/) }
+          it { is_expected.to contain_file('puppetdb-cli-config root').with_content(/"key":\s*"\/etc\/puppetlabs\/puppet\/ssl\/private_keys\/node1.example.com.pem"/) }
+        end
+
+        context "with server_urls => [ https://example.com:1234, https://example.com:5678], certificate => abc123 and private_key => def456" do
+          let(:params) { {
+            'server_urls' => [ 'https://example.com:1234', 'https://example.com:5678'],
+            'certificate' => 'abc123',
+            'private_key' => 'def456'
+          } }
+
+          include_examples 'puppetdb-cli config file structure', 'root', '/root/.puppetlabs'
+
+          it { is_expected.to contain_file('/root/.puppetlabs/puppet/ssl/certs/puppetdb-cli.crt').with(
+            'content' => 'abc123'
+          ) }
+
+          it { is_expected.to contain_file('/root/.puppetlabs/puppet/ssl/private_keys/puppetdb-cli.key').with(
+            'content' => 'def456'
+          ) }
+
+          it { is_expected.to contain_file('puppetdb-cli-config root').with_content(/"server_urls":\s*\[\s*"https:\/\/example.com:1234",\s*"https:\/\/example.com:5678"\s*\]/) }
+          it { is_expected.to contain_file('puppetdb-cli-config root').with_content(/"cacert":\s*"\/root\/.puppetlabs\/puppet\/ssl\/certs\/ca.pem"/) }
+          it { is_expected.to contain_file('puppetdb-cli-config root').with_content(/"cert":\s*"\/root\/.puppetlabs\/puppet\/ssl\/certs\/puppetdb-cli.crt"/) }
+          it { is_expected.to contain_file('puppetdb-cli-config root').with_content(/"key":\s*"\/root\/.puppetlabs\/puppet\/ssl\/private_keys\/puppetdb-cli.key"/) }
+        end
+
+        context "without parameters" do
+          let(:params) { {} }
+
+          it { expect { catalogue }.to raise_error(Puppet::ParseError, /expects a value for parameter 'server_urls'/) }
+        end
+      end
+
+      context "on node2.example.com with title jenkins" do
+        let(:node) { 'node2.example.com' }
+        let(:title) { 'jenkins' }
+
+        context "with server_urls => [ https://example.com:1234, https://example.com:5678], certificate => abc123 and private_key => def456" do
+          let(:params) { {
+            'server_urls' => [ 'https://example.com:1234', 'https://example.com:5678'],
+            'certificate' => '123abc',
+            'private_key' => '456def'
+          } }
+
+          include_examples 'puppetdb-cli config file structure', 'jenkins', '/var/lib/jenkins/.puppetlabs'
+
+          it { is_expected.to contain_file('/var/lib/jenkins/.puppetlabs/puppet/ssl/certs/puppetdb-cli.crt').with(
+            'content' => '123abc'
+          ) }
+
+          it { is_expected.to contain_file('/var/lib/jenkins/.puppetlabs/puppet/ssl/private_keys/puppetdb-cli.key').with(
+            'content' => '456def'
+          ) }
+
+          it { is_expected.to contain_file('puppetdb-cli-config jenkins').with_content(/"server_urls":\s*\[\s*"https:\/\/example.com:1234",\s*"https:\/\/example.com:5678"\s*\]/) }
+          it { is_expected.to contain_file('puppetdb-cli-config jenkins').with_content(/"cacert":\s*"\/var\/lib\/jenkins\/.puppetlabs\/puppet\/ssl\/certs\/ca.pem"/) }
+          it { is_expected.to contain_file('puppetdb-cli-config jenkins').with_content(/"cert":\s*"\/var\/lib\/jenkins\/.puppetlabs\/puppet\/ssl\/certs\/puppetdb-cli.crt"/) }
+          it { is_expected.to contain_file('puppetdb-cli-config jenkins').with_content(/"key":\s*"\/var\/lib\/jenkins\/.puppetlabs\/puppet\/ssl\/private_keys\/puppetdb-cli.key"/) }
+        end
+
+        context "with server_urls => https://example.com:1234" do
+          let(:params) { {
+            'server_urls' => 'https://example.com:1234'
+          } }
+
+          it { expect { catalogue }.to raise_error(Puppet::ParseError, /expects a value for parameters 'certificate' and 'private_key'/) }
+        end
+      end
+
+      context "on node3.example.com with title foobar" do
+        let(:node) { 'node3.example.com' }
+        let(:title) { 'foobar' }
+
+        context "with server_urls => https://foobar.example.com:8080, certificate => 987zyx and private_key => xyz789" do
+          let(:params) { {
+            'server_urls' => 'https://foobar.example.com:8080',
+            'certificate' => '987zyx',
+            'private_key' => 'xyz789'
+          } }
+
+          include_examples 'puppetdb-cli config file structure', 'foobar', '/home/foobar/.puppetlabs'
+
+          it { is_expected.to contain_file('/home/foobar/.puppetlabs/puppet/ssl/certs/puppetdb-cli.crt').with(
+            'content' => '987zyx'
+          ) }
+
+          it { is_expected.to contain_file('/home/foobar/.puppetlabs/puppet/ssl/private_keys/puppetdb-cli.key').with(
+            'content' => 'xyz789'
+          ) }
+
+          it { is_expected.to contain_file('puppetdb-cli-config foobar').with_content(/"server_urls":\s*"https:\/\/foobar.example.com:8080"/) }
+          it { is_expected.to contain_file('puppetdb-cli-config foobar').with_content(/"cacert":\s*"\/home\/foobar\/.puppetlabs\/puppet\/ssl\/certs\/ca.pem"/) }
+          it { is_expected.to contain_file('puppetdb-cli-config foobar').with_content(/"cert":\s*"\/home\/foobar\/.puppetlabs\/puppet\/ssl\/certs\/puppetdb-cli.crt"/) }
+          it { is_expected.to contain_file('puppetdb-cli-config foobar').with_content(/"key":\s*"\/home\/foobar\/.puppetlabs\/puppet\/ssl\/private_keys\/puppetdb-cli.key"/) }
+        end
+
+        context "with server_urls => https://example.com:1234" do
+          let(:params) { {
+            'server_urls' => 'https://example.com:1234'
+          } }
+
+          it { expect { catalogue }.to raise_error(Puppet::ParseError, /expects a value for parameters 'certificate' and 'private_key'/) }
+        end
+      end
+    end
+  end
+end

--- a/templates/puppetdb/cli.conf.erb
+++ b/templates/puppetdb/cli.conf.erb
@@ -1,8 +1,8 @@
 {
   "puppetdb": {
     "server_urls": <%- if @server_urls.is_a?(String) %>"<%= @server_urls %>"<%- else %><%= @server_urls %><%- end %>,
-    "cacert": "/etc/puppetlabs/puppet/ssl/certs/ca.pem",
-    "cert": "/etc/puppetlabs/puppet/ssl/certs/<%= @trusted['certname'] %>.pem",
-    "key": "/etc/puppetlabs/puppet/ssl/private_keys/<%= @trusted['certname'] %>.pem"
+    "cacert": "<%= @ssl_dir %>/certs/ca.pem",
+    "cert": "<%= @ssl_dir %>/certs/<%= @certificate_filename %>",
+    "key": "<%= @ssl_dir %>/private_keys/<%= @private_key_filename %>"
   }
 }


### PR DESCRIPTION
### Added

- Make sure we can use puppetdb-cli as a non-privileged user

---
Ticket: https://jira.uitdatabank.be/browse/OPS-827
