### PR TITLE
switch nodejs 14 aptly repo from trusty to xenial

### DIFF
--- a/manifests/apt/repositories.pp
+++ b/manifests/apt/repositories.pp
@@ -54,7 +54,7 @@ class profiles::apt::repositories {
 
   @apt::source { 'nodejs_14.x':
     location => "http://apt.uitdatabank.be/nodejs_14.x-${environment}",
-    release  => 'trusty',
+    release  => $facts['os']['distro']['codename'],
     repos    => 'main'
   }
 


### PR DESCRIPTION
### Added

- switch nodejs 14 aptly repo from trusty to xenial
---
Ticket: https://jira.uitdatabank.be/browse/UIT-1065
