### PR TITLE
Automatically create <name>-archive repository when creating <name> repository

### DIFF
--- a/manifests/aptly.pp
+++ b/manifests/aptly.pp
@@ -68,6 +68,10 @@ class profiles::aptly (
     aptly::repo { $repo:
       default_component => 'main'
     }
+
+    aptly::repo { "${repo}-archive":
+      default_component => 'main'
+    }
   }
 
   $mirrors.each |$name, $attributes| {

--- a/spec/classes/aptly_spec.rb
+++ b/spec/classes/aptly_spec.rb
@@ -126,7 +126,15 @@ describe 'profiles::aptly' do
             'default_component' => 'main'
           ) }
 
+          it { is_expected.to contain_aptly__repo('foo-archive').with(
+            'default_component' => 'main'
+          ) }
+
           it { is_expected.to contain_aptly__repo('bar').with(
+            'default_component' => 'main'
+          ) }
+
+          it { is_expected.to contain_aptly__repo('bar-archive').with(
             'default_component' => 'main'
           ) }
 
@@ -210,6 +218,10 @@ describe 'profiles::aptly' do
           ) }
 
           it { is_expected.to contain_aptly__repo('baz').with(
+            'default_component' => 'main'
+          ) }
+
+          it { is_expected.to contain_aptly__repo('baz-archive').with(
             'default_component' => 'main'
           ) }
 


### PR DESCRIPTION
### Changed
Automatically add corresponding <name>-archive repository when creating a repository in the aptly profile. Deployment uses this to keep the regular repo small and fast, but still be able to revert to an older version. 
It also allows to create an easier cleanup process, as everything in the *-archive repositories is essentially unused.

---
Ticket: https://jira.uitdatabank.be/browse/OPS-738
