### PR TITLE
Remove old UiT repo from UiT frontend deployment

### DIFF
--- a/manifests/deployment/uit/frontend.pp
+++ b/manifests/deployment/uit/frontend.pp
@@ -12,13 +12,12 @@ class profiles::deployment::uit::frontend (
 
   $basedir = '/var/www/uit-frontend/packages/app'
 
-  realize Apt::Source['publiq-uit']
   realize Apt::Source['uit-frontend']
 
   package { 'uit-frontend':
     ensure  => $version,
     notify  => Profiles::Deployment::Versions[$title],
-    require => [Apt::Source['publiq-uit'], Apt::Source['uit-frontend']]
+    require => Apt::Source['uit-frontend']
   }
 
   file { 'uit-frontend-config':

--- a/spec/classes/deployment/uit/frontend_spec.rb
+++ b/spec/classes/deployment/uit/frontend_spec.rb
@@ -14,12 +14,10 @@ describe 'profiles::deployment::uit::frontend' do
 
         it { is_expected.to compile.with_all_deps }
 
-        it { is_expected.to contain_apt__source('publiq-uit') }
         it { is_expected.to contain_apt__source('uit-frontend') }
 
         it { is_expected.to contain_package('uit-frontend').with( 'ensure' => 'latest') }
         it { is_expected.to contain_package('uit-frontend').that_notifies('Profiles::Deployment::Versions[profiles::deployment::uit::frontend]') }
-        it { is_expected.to contain_package('uit-frontend').that_requires('Apt::Source[publiq-uit]') }
         it { is_expected.to contain_package('uit-frontend').that_requires('Apt::Source[uit-frontend]') }
 
         it { is_expected.to contain_file('uit-frontend-config').with(


### PR DESCRIPTION
### Removed

- Remove old UiT repository from UiT frontend deployment

---
Ticket: https://jira.uitdatabank.be/browse/UIT-1183
