### PR TITLE
Updated apt module fixed bug, that required the keyserver attribute

### DIFF
--- a/manifests/apt/keys.pp
+++ b/manifests/apt/keys.pp
@@ -2,19 +2,16 @@ class profiles::apt::keys {
 
   apt::key { 'Infra CultuurNet':
     id     => '2380EA3E50D3776DFC1B03359F4935C80DC9EA95',
-    server => 'keyserver.ubuntu.com',
     source => 'https://apt.publiq.be/gpgkey/cultuurnet.gpg.key'
   }
 
   apt::key { 'publiq Infrastructure':
     id     => 'AD726BD2A48017B060AA43FA4A49242DE36CDCAF',
-    server => 'keyserver.ubuntu.com',
     source => 'https://apt.publiq.be/gpgkey/publiq.gpg.key'
   }
 
   @apt::key { 'aptly':
     id     => '26DA9D8630302E0B86A7A2CBED75B5A4483DA07C',
-    server => 'keyserver.ubuntu.com',
     source => 'https://www.aptly.info/pubkey.txt'
   }
 
@@ -25,7 +22,6 @@ class profiles::apt::keys {
 
   @apt::key { 'docker':
     id     => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88',
-    server => 'keyserver.ubuntu.com',
     source => 'https://download.docker.com/linux/ubuntu/gpg'
   }
 }

--- a/spec/classes/apt/keys_spec.rb
+++ b/spec/classes/apt/keys_spec.rb
@@ -6,7 +6,10 @@ describe 'profiles::apt::keys' do
       let(:facts) { facts }
 
       context "with all virtual resources realized" do
-        let(:pre_condition) { 'Apt::Key <| |>' }
+        let(:pre_condition) { [
+          'include ::apt',
+          'Apt::Key <| |>'
+        ] }
 
         it { is_expected.to compile.with_all_deps }
 

--- a/spec/classes/apt/repositories_spec.rb
+++ b/spec/classes/apt/repositories_spec.rb
@@ -16,7 +16,10 @@ describe 'profiles::apt::repositories' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       context "with all virtual resources realized" do
-        let(:pre_condition) { 'Apt::Source <| |>' }
+        let(:pre_condition) { [
+          'include ::apt',
+          'Apt::Source <| |>'
+        ] }
 
         it { is_expected.to compile.with_all_deps }
 

--- a/spec/classes/deployment/repositories_spec.rb
+++ b/spec/classes/deployment/repositories_spec.rb
@@ -17,7 +17,10 @@ describe 'profiles::deployment::repositories' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       context "with all virtual resources realized" do
-        let(:pre_condition) { 'Apt::Source <| |>' }
+        let(:pre_condition) { [
+          'include ::apt',
+          'Apt::Source <| |>'
+        ] }
 
         it { is_expected.to compile.with_all_deps }
 


### PR DESCRIPTION
### Changed

Declaration of apt keys does not need the keyserver attribute anymore, when it is not being used. This was caused by a bug in the old version of the apt module we used (2.3.x). Since upgrading the apt module to 4.x, the bug is fixed and the keyserver attributes can be removed where they are not used.
