### PR TITLE
Do not recursively manage the Drupal sites/default/files directory

### DIFF
--- a/manifests/deployment/uit/cms.pp
+++ b/manifests/deployment/uit/cms.pp
@@ -57,7 +57,6 @@ class profiles::deployment::uit::cms (
     source  => $files_source,
     owner   => 'www-data',
     group   => 'www-data',
-    recurse => true,
     require => [ Package['uit-cms'], Package['uit-cms-files']]
   }
 


### PR DESCRIPTION
### Changed

- Do not recursively manage the Drupal sites/default/files directory

---
Ticket: https://jira.uitdatabank.be/browse/UIT-1214
