### PR TITLE
Make HTTPS vhost for aptly profile optional

### DIFF
--- a/spec/classes/aptly_spec.rb
+++ b/spec/classes/aptly_spec.rb
@@ -12,7 +12,6 @@ describe 'profiles::aptly' do
       context "with api_hostname => aptly.example.com and certificate => wildcard.example.com" do
         let(:params) { {
           'api_hostname' => 'aptly.example.com',
-          'certificate'  => 'wildcard.example.com'
         } }
 
         it { is_expected.to compile.with_all_deps }
@@ -40,12 +39,7 @@ describe 'profiles::aptly' do
           's3_publish_endpoints' => {}
         ) }
 
-        it { is_expected.to contain_profiles__apache__vhost__redirect('http://aptly.example.com').with(
-          'destination' => 'https://aptly.example.com'
-        ) }
-
-        it { is_expected.to contain_profiles__apache__vhost__reverse_proxy('https://aptly.example.com').with(
-          'certificate' => 'wildcard.example.com',
+        it { is_expected.to contain_profiles__apache__vhost__reverse_proxy('http://aptly.example.com').with(
           'destination' => 'http://127.0.0.1:8081/'
         ) }
 
@@ -263,7 +257,6 @@ describe 'profiles::aptly' do
         let(:params) { {} }
 
         it { expect { catalogue }.to raise_error(Puppet::ParseError, /expects a value for parameter 'api_hostname'/) }
-        it { expect { catalogue }.to raise_error(Puppet::ParseError, /expects a value for parameter 'certificate'/) }
       end
     end
   end

--- a/spec/classes/aptly_spec.rb
+++ b/spec/classes/aptly_spec.rb
@@ -39,6 +39,8 @@ describe 'profiles::aptly' do
           's3_publish_endpoints' => {}
         ) }
 
+        it { is_expected.to_not contain_profiles__apache__vhost__redirect('http://foobar.example.com') }
+
         it { is_expected.to contain_profiles__apache__vhost__reverse_proxy('http://aptly.example.com').with(
           'destination' => 'http://127.0.0.1:8081/'
         ) }


### PR DESCRIPTION
### Changed

- Make HTTPS vhost for aptly profile optional, pivoting on the existence of a certificate parameter

---
Ticket: https://jira.uitdatabank.be/browse/OPS-897
