### PR TITLE
Make HTTPS vhost for jenkins controller profile optional

### DIFF
--- a/spec/classes/jenkins/controller_spec.rb
+++ b/spec/classes/jenkins/controller_spec.rb
@@ -9,11 +9,10 @@ describe 'profiles::jenkins::controller' do
     context "on #{os}" do
       let(:facts) { facts }
 
-      context "with url => https://jenkins.example.com/, admin_password => passw0rd and certificate => wildcard.example.com" do
+      context "with url => https://jenkins.example.com/ and admin_password => passw0rd" do
         let(:params) { {
           'url'            => 'https://jenkins.example.com/',
-          'admin_password' => 'passw0rd',
-          'certificate'    => 'wildcard.example.com'
+          'admin_password' => 'passw0rd'
         } }
 
         it { is_expected.to compile.with_all_deps }
@@ -21,8 +20,8 @@ describe 'profiles::jenkins::controller' do
         it { is_expected.to contain_class('profiles::jenkins::controller').with(
           'url'                          => 'https://jenkins.example.com/',
           'admin_password'               => 'passw0rd',
-          'certificate'                  => 'wildcard.example.com',
           'version'                      => 'latest',
+          'certificate'                  => nil,
           'docker_registry_url'          => nil,
           'docker_registry_credentialid' => nil,
           'credentials'                  => [],
@@ -54,13 +53,10 @@ describe 'profiles::jenkins::controller' do
           'controller_url' => 'https://jenkins.example.com/'
         ) }
 
-        it { is_expected.to contain_profiles__apache__vhost__redirect('http://jenkins.example.com').with(
-          'destination' => 'https://jenkins.example.com'
-        ) }
+        it { is_expected.to_not contain_profiles__apache__vhost__redirect('http://jenkins.example.com') }
 
-        it { is_expected.to contain_profiles__apache__vhost__reverse_proxy('https://jenkins.example.com').with(
+        it { is_expected.to contain_profiles__apache__vhost__reverse_proxy('http://jenkins.example.com').with(
           'destination'           => 'http://127.0.0.1:8080/',
-          'certificate'           => 'wildcard.example.com',
           'preserve_host'         => true,
           'allow_encoded_slashes' => 'nodecode',
           'proxy_keywords'        => 'nocanon',
@@ -71,7 +67,7 @@ describe 'profiles::jenkins::controller' do
         it { is_expected.to contain_class('profiles::jenkins::controller::install').that_notifies('Class[profiles::jenkins::controller::service]') }
         it { is_expected.to contain_class('profiles::jenkins::controller::configuration').that_requires('Class[profiles::jenkins::controller::service]') }
         it { is_expected.to contain_class('profiles::jenkins::controller::configuration').that_requires('Class[profiles::jenkins::cli]') }
-        it { is_expected.to contain_class('profiles::jenkins::cli').that_requires('Profiles::Apache::Vhost::Reverse_proxy[https://jenkins.example.com]') }
+        it { is_expected.to contain_class('profiles::jenkins::cli').that_requires('Profiles::Apache::Vhost::Reverse_proxy[http://jenkins.example.com]') }
       end
 
       context "with url => https://foobar.example.com/, admin_password => letmein, certificate => foobar.example.com, version => 1.2.3, docker_registry_url => https://my.docker.registry.com/, docker_registry_credentialid => my_docker_cred, credentials => [{ id => 'token1', type => 'string', secret => 'secret1'}, { id => 'token2', type => 'string', secret => 'secret2'}], global_libraries => [{'git_url' => 'git@foo.com:bar/baz.git', 'git_ref' => 'develop', 'credential_id' => 'gitkey'}, {'git_url' => 'git@example.com:org/repo.git', 'git_ref' => 'main', 'credential_id' => 'mygitcred'}], pipelines => [{ 'name' => 'baz', 'git_url' => 'git@github.com:bar/baz.git', 'git_ref' => 'refs/heads/develop', 'credential_id' => 'gitkey', keep_builds => 10 }, { 'name' => 'repo', 'git_url' => 'git@example.com:org/repo.git', 'git_ref' => 'main', 'credential_id' => 'mygitcred', keep_builds => '2' }] and users => [{'id' => 'foo', 'name' => 'Foo Bar', 'password' => 'baz', 'email' => 'foo@example.com'}, {'id' => 'user1', 'name' => 'User One', 'password' => 'passw0rd', 'email' => 'user1@example.com'}]" do
@@ -195,7 +191,6 @@ describe 'profiles::jenkins::controller' do
 
         it { expect { catalogue }.to raise_error(Puppet::ParseError, /expects a value for parameter 'url'/) }
         it { expect { catalogue }.to raise_error(Puppet::ParseError, /expects a value for parameter 'admin_password'/) }
-        it { expect { catalogue }.to raise_error(Puppet::ParseError, /expects a value for parameter 'certificate'/) }
       end
     end
   end


### PR DESCRIPTION
### Changed

- Make HTTPS vhost for jenkins controller profile optional, pivoting on the existence of a certificate

---
Ticket: https://jira.uitdatabank.be/browse/OPS-897
