### PR TITLE
[UPS-4049] update uitpas.be frontend deployment to new jenkins pipeline

### DIFF
--- a/manifests/apt/repositories.pp
+++ b/manifests/apt/repositories.pp
@@ -143,6 +143,12 @@ class profiles::apt::repositories {
     repos    => 'main'
   }
 
+  @apt::source { 'uitpas-website-frontend':
+    location => "https://apt.publiq.be/uitpas-website-frontend-${environment}",
+    release  => $facts['os']['distro']['codename'],
+    repos    => 'main'
+  }
+
   @apt::source { 'newrelic':
     location     => "https://apt.publiq.be/newrelic-${environment}",
     release      => $facts['os']['distro']['codename'],

--- a/manifests/deployment/uitpas_be/frontend.pp
+++ b/manifests/deployment/uitpas_be/frontend.pp
@@ -8,49 +8,49 @@ class profiles::deployment::uitpas_be::frontend (
   Optional[String] $puppetdb_url        = undef
 ) inherits ::profiles {
 
-  $basedir = '/var/www/uitpasbe-frontend'
+  $basedir = '/var/www/uitpas-website-frontend'
 
-  realize Apt::Source['publiq-uitpasbe']
+  realize Apt::Source['uitpas-website-frontend']
 
-  package { 'uitpasbe-frontend':
+  package { 'uitpas-website-frontend':
     ensure  => $version,
     notify  => Profiles::Deployment::Versions[$title],
-    require => Apt::Source['publiq-uitpasbe']
+    require => Apt::Source['uitpas-website-frontend']
   }
 
-  file { 'uitpasbe-frontend-config':
+  file { 'uitpas-website-frontend-config':
     ensure  => 'file',
     path    => "${basedir}/.env",
     owner   => 'www-data',
     group   => 'www-data',
     source  => $config_source,
-    require => Package['uitpasbe-frontend']
+    require => Package['uitpas-website-frontend']
   }
 
   if $service_manage {
     if $env_defaults_source {
-      file { '/etc/default/uitpasbe-frontend':
+      file { '/etc/default/uitpas-website-frontend':
         ensure => 'file',
         owner  => 'root',
         group  => 'root',
         source => $env_defaults_source,
-        notify => Service['uitpasbe-frontend']
+        notify => Service['uitpas-website-frontend']
       }
     }
 
-    service { 'uitpasbe-frontend':
+    service { 'uitpas-website-frontend':
       ensure    => $service_ensure,
       enable    => $service_enable,
-      require   => Package['uitpasbe-frontend'],
+      require   => Package['uitpas-website-frontend'],
       hasstatus => true
     }
 
-    File['uitpasbe-frontend-config'] ~> Service['uitpasbe-frontend']
+    File['uitpas-website-frontend-config'] ~> Service['uitpas-website-frontend']
   }
 
   profiles::deployment::versions { $title:
     project      => 'uitpasbe',
-    packages     => 'uitpasbe-frontend',
+    packages     => 'uitpas-website-frontend',
     puppetdb_url => $puppetdb_url
   }
 }

--- a/spec/classes/apt/repositories_spec.rb
+++ b/spec/classes/apt/repositories_spec.rb
@@ -277,6 +277,17 @@ describe 'profiles::apt::repositories' do
               'release'      => 'xenial'
             ) }
 
+            it { is_expected.to contain_apt__source('uitpas-website-frontend').with(
+              'location'     => 'https://apt.publiq.be/uitpas-website-frontend-acceptance',
+              'ensure'       => 'present',
+              'repos'        => 'main',
+              'include'      => {
+                'deb' => 'true',
+                'src' => 'false'
+              },
+              'release'      => 'xenial'
+            ) }
+
             it { is_expected.to contain_apt__source('newrelic').with(
               'location'     => 'https://apt.publiq.be/newrelic-acceptance',
               'ensure'       => 'present',

--- a/spec/classes/deployment/uitpas_be/frontend_spec.rb
+++ b/spec/classes/deployment/uitpas_be/frontend_spec.rb
@@ -14,36 +14,36 @@ describe 'profiles::deployment::uitpas_be::frontend' do
 
         it { is_expected.to compile.with_all_deps }
 
-        it { is_expected.to contain_apt__source('publiq-uitpasbe') }
+        it { is_expected.to contain_apt__source('uitpas-website-frontend') }
 
-        it { is_expected.to contain_package('uitpasbe-frontend').with( 'ensure' => 'latest') }
-        it { is_expected.to contain_package('uitpasbe-frontend').that_notifies('Profiles::Deployment::Versions[profiles::deployment::uitpas_be::frontend]') }
-        it { is_expected.to contain_package('uitpasbe-frontend').that_requires('Apt::Source[publiq-uitpasbe]') }
+        it { is_expected.to contain_package('uitpas-website-frontend').with( 'ensure' => 'latest') }
+        it { is_expected.to contain_package('uitpas-website-frontend').that_notifies('Profiles::Deployment::Versions[profiles::deployment::uitpas_be::frontend]') }
+        it { is_expected.to contain_package('uitpas-website-frontend').that_requires('Apt::Source[uitpas-website-frontend]') }
 
-        it { is_expected.to contain_file('uitpasbe-frontend-config').with(
+        it { is_expected.to contain_file('uitpas-website-frontend-config').with(
           'ensure' => 'file',
-          'path'   => '/var/www/uitpasbe-frontend/.env',
+          'path'   => '/var/www/uitpas-website-frontend/.env',
           'source' => '/foo',
           'owner'  => 'www-data',
           'group'  => 'www-data'
         ) }
 
-        it { is_expected.to contain_file('uitpasbe-frontend-config').that_requires('Package[uitpasbe-frontend]') }
+        it { is_expected.to contain_file('uitpas-website-frontend-config').that_requires('Package[uitpas-website-frontend]') }
 
-        it { is_expected.not_to contain_file('/etc/defaults/uitpasbe-frontend') }
+        it { is_expected.not_to contain_file('/etc/defaults/uitpas-website-frontend') }
 
-        it { is_expected.to contain_service('uitpasbe-frontend').with(
+        it { is_expected.to contain_service('uitpas-website-frontend').with(
           'ensure'    => 'running',
           'enable'    => true,
           'hasstatus' => true
         ) }
 
-        it { is_expected.to contain_service('uitpasbe-frontend').that_requires('Package[uitpasbe-frontend]') }
-        it { is_expected.to contain_file('uitpasbe-frontend-config').that_notifies('Service[uitpasbe-frontend]') }
+        it { is_expected.to contain_service('uitpas-website-frontend').that_requires('Package[uitpas-website-frontend]') }
+        it { is_expected.to contain_file('uitpas-website-frontend-config').that_notifies('Service[uitpas-website-frontend]') }
 
         it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uitpas_be::frontend').with(
           'project'      => 'uitpasbe',
-          'packages'     => 'uitpasbe-frontend',
+          'packages'     => 'uitpas-website-frontend',
           'puppetdb_url' => nil
         ) }
 
@@ -54,7 +54,7 @@ describe 'profiles::deployment::uitpas_be::frontend' do
             } )
           }
 
-          it { is_expected.not_to contain_service('uitpasbe-frontend') }
+          it { is_expected.not_to contain_service('uitpas-website-frontend') }
         end
       end
     end
@@ -74,13 +74,13 @@ describe 'profiles::deployment::uitpas_be::frontend' do
       context "on #{os}" do
         let(:facts) { facts }
 
-        it { is_expected.to contain_file('uitpasbe-frontend-config').with(
+        it { is_expected.to contain_file('uitpas-website-frontend-config').with(
           'source' => '/bar',
         ) }
 
-        it { is_expected.to contain_package('uitpasbe-frontend').with( 'ensure' => '1.2.3') }
+        it { is_expected.to contain_package('uitpas-website-frontend').with( 'ensure' => '1.2.3') }
 
-        it { is_expected.to contain_service('uitpasbe-frontend').with(
+        it { is_expected.to contain_service('uitpas-website-frontend').with(
           'ensure'    => 'stopped',
           'enable'    => false
         ) }


### PR DESCRIPTION
orig pipeline: https://jenkins.uitdatabank.be/job/Package_UiTPAS.be_frontend/
new pipeline: https://jenkins.publiq.be/job/UiTPAS%20website%20frontend/

Jenkinsfile: https://github.com/cultuurnet/uitpasbe-frontend/blob/main/Jenkinsfile
Rake tasks: https://github.com/cultuurnet/uitpasbe-frontend/tree/main/lib/tasks/uitpas-website-frontend

all deployed and ran successfully.
the changes in this PR adjust the puppet deploy of uitpas.be frontend to the new pipeline / packagename / servicename