### PR TITLE
Remove unnecessary saving of deployment versions in local files

### DIFF
--- a/manifests/deployment/appconfig.pp
+++ b/manifests/deployment/appconfig.pp
@@ -16,7 +16,6 @@ class profiles::deployment::appconfig (
   profiles::deployment::versions { $title:
     project         => 'publiq',
     packages        => 'publiq-appconfig',
-    destination_dir => '/var/run',
     puppetdb_url    => $puppetdb_url,
     require         => Class['profiles::puppetserver::cache_clear']
   }

--- a/manifests/deployment/infrastructure.pp
+++ b/manifests/deployment/infrastructure.pp
@@ -16,7 +16,6 @@ class profiles::deployment::infrastructure (
   profiles::deployment::versions { $title:
     project         => 'publiq',
     packages        => 'publiq-infrastructure',
-    destination_dir => '/var/run',
     puppetdb_url    => $puppetdb_url,
     require         => Class['profiles::puppetserver::cache_clear']
   }

--- a/manifests/deployment/prototypes.pp
+++ b/manifests/deployment/prototypes.pp
@@ -13,7 +13,6 @@ class profiles::deployment::prototypes (
   profiles::deployment::versions { $title:
     project         => 'publiq',
     packages        => 'publiq-prototypes',
-    destination_dir => '/var/run',
     puppetdb_url    => $puppetdb_url
   }
 }

--- a/manifests/deployment/versions.pp
+++ b/manifests/deployment/versions.pp
@@ -1,33 +1,14 @@
 define profiles::deployment::versions (
   String                                    $project,
   Variant[ Optional[String], Array[String]] $packages        = undef,
-  String                                    $destination_dir = '/var/www',
   Optional[String]                          $puppetdb_url    = undef
 ) {
 
   include ::profiles
   include ::profiles::deployment
 
-  realize Package['jq']
-
   if $packages {
-    any2array($packages).each |$package| {
-      exec { "update versions.${project} file for package ${package}":
-        command     => "facter -pj ${project}_deployment_version | jq '.[\"${project}_deployment_version\"]' > ${destination_dir}/versions.${project}",
-        path        => [ '/bin', '/usr/local/bin', '/usr/bin', '/opt/puppetlabs/bin'],
-        require     => Package['jq'],
-        subscribe   => Package[$package],
-        refreshonly => true
-      }
-
-      exec { "update versions.${project}.${package} file for package ${package}":
-        command     => "facter -pj ${project}_deployment_version.${package} | jq '.[\"${project}_deployment_version.${package}\"]' > ${destination_dir}/versions.${project}.${package}",
-        path        => [ '/bin', '/usr/local/bin', '/usr/bin', '/opt/puppetlabs/bin'],
-        require     => Package['jq'],
-        subscribe   => Package[$package],
-        refreshonly => true
-      }
-
+    [$packages].flatten.each |$package| {
       if $puppetdb_url {
         exec { "update facts for package ${package}":
           command     => "update_facts -p ${puppetdb_url}",

--- a/spec/classes/deployment/appconfig_spec.rb
+++ b/spec/classes/deployment/appconfig_spec.rb
@@ -72,7 +72,6 @@ describe 'profiles::deployment::appconfig' do
         it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::appconfig').with(
           'project'         => 'publiq',
           'packages'        => 'publiq-appconfig',
-          'destination_dir' => '/var/run',
           'puppetdb_url'    => 'http://example.com:8000'
         ) }
       end

--- a/spec/classes/deployment/infrastructure_spec.rb
+++ b/spec/classes/deployment/infrastructure_spec.rb
@@ -72,7 +72,6 @@ describe 'profiles::deployment::infrastructure' do
         it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::infrastructure').with(
           'project'         => 'publiq',
           'packages'        => 'publiq-infrastructure',
-          'destination_dir' => '/var/run',
           'puppetdb_url'    => 'http://example.com:8000'
         ) }
       end

--- a/spec/classes/deployment/prototypes_spec.rb
+++ b/spec/classes/deployment/prototypes_spec.rb
@@ -63,7 +63,6 @@ describe 'profiles::deployment::prototypes' do
         it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::prototypes').with(
           'project'         => 'publiq',
           'packages'        => 'publiq-prototypes',
-          'destination_dir' => '/var/run',
           'puppetdb_url'    => 'http://example.com:8000'
         ) }
       end

--- a/spec/defines/deployment/versions_spec.rb
+++ b/spec/defines/deployment/versions_spec.rb
@@ -14,44 +14,16 @@ describe 'profiles::deployment::versions' do
 
         it { is_expected.to compile.with_all_deps }
 
-        it { is_expected.to contain_package('jq').with(
-          'ensure' => 'present'
-          )
-        }
-
-        it { is_expected.to have_exec_resource_count(1) }
-
-        context "with packages => foo and destination_dir => /tmp" do
+        context "with packages => foo" do
           let(:pre_condition) { 'package { "foo":}' }
 
           let(:params) {
             super().merge( {
-              'packages'        => 'foo',
-              'destination_dir' => '/tmp'
+              'packages'        => 'foo'
             } )
           }
 
-          it { is_expected.to contain_exec('update versions.example file for package foo').with(
-            'command'     => 'facter -pj example_deployment_version | jq \'.["example_deployment_version"]\' > /tmp/versions.example',
-            'path'        => [ '/bin', '/usr/local/bin', '/usr/bin', '/opt/puppetlabs/bin'],
-            'refreshonly' => true
-            )
-          }
-
-          it { is_expected.to contain_exec('update versions.example.foo file for package foo').with(
-            'command'     => 'facter -pj example_deployment_version.foo | jq \'.["example_deployment_version.foo"]\' > /tmp/versions.example.foo',
-            'path'        => [ '/bin', '/usr/local/bin', '/usr/bin', '/opt/puppetlabs/bin'],
-            'refreshonly' => true
-            )
-          }
-
           it { is_expected.not_to contain_exec('update facts for package foo') }
-
-          it { is_expected.to contain_exec('update versions.example file for package foo').that_subscribes_to('Package[foo]') }
-          it { is_expected.to contain_exec('update versions.example.foo file for package foo').that_subscribes_to('Package[foo]') }
-
-          it { is_expected.to contain_package('jq').that_comes_before('Exec[update versions.example file for package foo]') }
-          it { is_expected.to contain_package('jq').that_comes_before('Exec[update versions.example.foo file for package foo]') }
         end
 
         context "with packages => [ 'bar', 'baz'] and puppetdb_url => http://localhost:8080" do
@@ -62,34 +34,6 @@ describe 'profiles::deployment::versions' do
               'packages'     => [ 'bar', 'baz'],
               'puppetdb_url' => 'http://localhost:8080'
             } )
-          }
-
-          it { is_expected.to contain_exec('update versions.example file for package bar').with(
-            'command'     => 'facter -pj example_deployment_version | jq \'.["example_deployment_version"]\' > /var/www/versions.example',
-            'path'        => [ '/bin', '/usr/local/bin', '/usr/bin', '/opt/puppetlabs/bin'],
-            'refreshonly' => true
-            )
-          }
-
-          it { is_expected.to contain_exec('update versions.example file for package baz').with(
-            'command'     => 'facter -pj example_deployment_version | jq \'.["example_deployment_version"]\' > /var/www/versions.example',
-            'path'        => [ '/bin', '/usr/local/bin', '/usr/bin', '/opt/puppetlabs/bin'],
-            'refreshonly' => true
-            )
-          }
-
-          it { is_expected.to contain_exec('update versions.example.bar file for package bar').with(
-            'command'     => 'facter -pj example_deployment_version.bar | jq \'.["example_deployment_version.bar"]\' > /var/www/versions.example.bar',
-            'path'        => [ '/bin', '/usr/local/bin', '/usr/bin', '/opt/puppetlabs/bin'],
-            'refreshonly' => true
-            )
-          }
-
-          it { is_expected.to contain_exec('update versions.example.baz file for package baz').with(
-            'command'     => 'facter -pj example_deployment_version.baz | jq \'.["example_deployment_version.baz"]\' > /var/www/versions.example.baz',
-            'path'        => [ '/bin', '/usr/local/bin', '/usr/bin', '/opt/puppetlabs/bin'],
-            'refreshonly' => true
-            )
           }
 
           it { is_expected.to contain_exec('update facts for package bar').with(
@@ -106,18 +50,8 @@ describe 'profiles::deployment::versions' do
             )
           }
 
-          it { is_expected.to contain_exec('update versions.example file for package bar').that_subscribes_to('Package[bar]') }
-          it { is_expected.to contain_exec('update versions.example.bar file for package bar').that_subscribes_to('Package[bar]') }
           it { is_expected.to contain_exec('update facts for package bar').that_subscribes_to('Package[bar]') }
-
-          it { is_expected.to contain_exec('update versions.example file for package baz').that_subscribes_to('Package[baz]') }
-          it { is_expected.to contain_exec('update versions.example.baz file for package baz').that_subscribes_to('Package[baz]') }
           it { is_expected.to contain_exec('update facts for package baz').that_subscribes_to('Package[baz]') }
-
-          it { is_expected.to contain_package('jq').that_comes_before('Exec[update versions.example file for package bar]') }
-          it { is_expected.to contain_package('jq').that_comes_before('Exec[update versions.example file for package baz]') }
-          it { is_expected.to contain_package('jq').that_comes_before('Exec[update versions.example.bar file for package bar]') }
-          it { is_expected.to contain_package('jq').that_comes_before('Exec[update versions.example.baz file for package baz]') }
 
           it { is_expected.to contain_exec('update facts for package bar').that_subscribes_to('Class[profiles::deployment]') }
           it { is_expected.to contain_exec('update facts for package baz').that_subscribes_to('Class[profiles::deployment]') }


### PR DESCRIPTION
### Removed

- Remove old implementation of /versions which uses local files 

---
Ticket: https://jira.uitdatabank.be/browse/OPS-904
