### PR TITLE
Add Python 3.7 support to Ubuntu 18.04

### DIFF
--- a/manifests/apt/repositories.pp
+++ b/manifests/apt/repositories.pp
@@ -47,6 +47,8 @@ class profiles::apt::repositories {
         release  => $facts['os']['distro']['codename'],
         repos    => 'main'
       }
+
+      @apt::ppa { 'ppa:deadsnakes/ppa': }
     }
   }
 

--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -1,0 +1,14 @@
+class profiles::python (
+  String $version = '3.6'
+) inherits ::profiles {
+
+  if $version == '3.7' {
+    realize Apt::Ppa['ppa:deadsnakes/ppa']
+
+    Apt::Ppa['ppa:deadsnakes/ppa'] -> Package["python${version}"]
+  }
+
+  package { "python${version}":
+    ensure => 'installed'
+  }
+}

--- a/spec/classes/apt/repositories_spec.rb
+++ b/spec/classes/apt/repositories_spec.rb
@@ -20,7 +20,8 @@ describe 'profiles::apt::repositories' do
       context "with all virtual resources realized" do
         let(:pre_condition) { [
           'include ::apt',
-          'Apt::Source <| |>'
+          'Apt::Source <| |>',
+          'Apt::Ppa <| |>',
         ] }
 
         it { is_expected.to compile.with_all_deps }
@@ -48,6 +49,8 @@ describe 'profiles::apt::repositories' do
         when '14.04'
           context "in the testing environment" do
             let(:environment) { 'testing' }
+
+            it { is_expected.not_to contain_apt__ppa('ppa:deadsnakes/ppa') }
 
             it { is_expected.to contain_apt__source('cultuurnet-tools').with(
               'location' => 'http://apt.uitdatabank.be/tools-legacy-testing',
@@ -143,6 +146,8 @@ describe 'profiles::apt::repositories' do
         when '16.04'
           context "in the acceptance environment" do
             let(:environment) { 'acceptance' }
+
+            it { is_expected.not_to contain_apt__ppa('ppa:deadsnakes/ppa') }
 
             it { is_expected.to contain_apt__source('cultuurnet-tools').with(
               'location' => 'http://apt.uitdatabank.be/tools-acceptance',
@@ -436,6 +441,9 @@ describe 'profiles::apt::repositories' do
               'release'      => 'xenial'
             ) }
           end
+
+        when '18.04'
+          it { is_expected.to contain_apt__ppa('ppa:deadsnakes/ppa') }
         end
       end
     end

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'profiles::python' do
+  include_examples 'operating system support'
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      it { is_expected.to compile.with_all_deps }
+
+      context "without parameters" do
+        let(:params) { {} }
+
+        it { is_expected.to contain_package('python3.6').with(
+          'ensure' => 'installed'
+        ) }
+      end
+
+      context "with version => 3.7" do
+        let(:params) { { 'version' => '3.7' } }
+
+        case facts[:os]['release']['major']
+        when '18.04'
+          it { is_expected.to contain_apt__ppa('ppa:deadsnakes/ppa') }
+
+          it { is_expected.to contain_package('python3.7').with(
+            'ensure' => 'installed'
+          ) }
+
+          it { is_expected.to contain_package('python3.7').that_requires('Apt::Ppa[ppa:deadsnakes/ppa]') }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Added

- Python 3.7 on Ubuntu 18.04 through the deadsnakes PPA
