### PR TITLE
Make the creation of the <name>-archive repository configurable

### DIFF
--- a/manifests/aptly.pp
+++ b/manifests/aptly.pp
@@ -9,7 +9,7 @@ class profiles::aptly (
   String                         $api_bind          = '127.0.0.1',
   Integer                        $api_port          = 8081,
   Hash                           $publish_endpoints = {},
-  Variant[String, Array[String]] $repositories      = [],
+  Hash                           $repositories      = {},
   Hash                           $mirrors           = {}
 ) inherits ::profiles {
 
@@ -81,13 +81,17 @@ class profiles::aptly (
     require     => [ Class['aptly'], User['aptly']]
   }
 
-  [$repositories].flatten.each |$repo| {
+  $repositories.each |$repo, $attributes| {
+    $archive = $attributes['archive']
+
     aptly::repo { $repo:
       default_component => 'main'
     }
 
-    aptly::repo { "${repo}-archive":
-      default_component => 'main'
+    if $archive {
+      aptly::repo { "${repo}-archive":
+        default_component => 'main'
+      }
     }
   }
 

--- a/spec/classes/aptly_spec.rb
+++ b/spec/classes/aptly_spec.rb
@@ -85,7 +85,7 @@ describe 'profiles::aptly' do
           'certificate'  => 'foobar.example.com'
         } }
 
-        context "with signing_keys => { 'test' => { 'id' => '1234ABCD', 'source' => '/tmp/test.key' }}, version => 1.2.3, data_dir => '/data/aptly', api_bind => 1.2.3.4, api_port => 8080, repositories => [ 'foo', 'bar'] and mirrors => { 'mirror' => { 'location => 'http://mirror.example.com', distribution => 'unstable', components => ['main', 'contrib'], key => 'Ubuntu archive' }}" do
+        context "with signing_keys => { 'test' => { 'id' => '1234ABCD', 'source' => '/tmp/test.key' }}, version => 1.2.3, data_dir => '/data/aptly', api_bind => 1.2.3.4, api_port => 8080, repositories => { 'foo' => {'archive' => false}, 'bar' => {'archive' => true}} and mirrors => {'mirror' => {'location => 'http://mirror.example.com', distribution => 'unstable', components => ['main', 'contrib'], key => 'Ubuntu archive'}}" do
           let(:params) { super().merge(
             {
               'signing_keys' => { 'test' => { 'id' => '1234ABCD', 'source' => '/tmp/test.key' }},
@@ -93,7 +93,7 @@ describe 'profiles::aptly' do
               'data_dir'     => '/data/aptly',
               'api_bind'     => '1.2.3.4',
               'api_port'     => 8080,
-              'repositories' => [ 'foo', 'bar'],
+              'repositories' => {'foo' => {'archive' => false}, 'bar' => {'archive' => true}},
               'mirrors'      => { 'mirror' => {
                                                  'location'     => 'http://mirror.example.com',
                                                  'distribution' => 'unstable',
@@ -133,9 +133,7 @@ describe 'profiles::aptly' do
             'default_component' => 'main'
           ) }
 
-          it { is_expected.to contain_aptly__repo('foo-archive').with(
-            'default_component' => 'main'
-          ) }
+          it { is_expected.not_to contain_aptly__repo('foo-archive') }
 
           it { is_expected.to contain_aptly__repo('bar').with(
             'default_component' => 'main'
@@ -181,7 +179,7 @@ describe 'profiles::aptly' do
                    'awsSecretAccessKey' => 'abc'
                  }
                },
-              'repositories'      => 'baz',
+              'repositories'      => {'baz' => {}},
               'mirrors'           => { 'mirror1' => {
                                                       'location'     => 'http://mirror1.example.com' ,
                                                       'distribution' => 'testing',
@@ -228,9 +226,7 @@ describe 'profiles::aptly' do
             'default_component' => 'main'
           ) }
 
-          it { is_expected.to contain_aptly__repo('baz-archive').with(
-            'default_component' => 'main'
-          ) }
+          it { is_expected.not_to contain_aptly__repo('baz-archive') }
 
           it { is_expected.to contain_aptly__mirror('mirror1').with(
             'location'      => 'http://mirror1.example.com',


### PR DESCRIPTION
### Changed

- Make the creation of the aptly repositories more explicit by adding an attribute for creation of the <name>-archive repository. Make it default to false, as this is the most intuitive course of action.