### PR TITLE
Remove old nodejs repository definitions

### DIFF
--- a/manifests/apt/repositories.pp
+++ b/manifests/apt/repositories.pp
@@ -59,27 +59,19 @@ class profiles::apt::repositories {
   }
 
   @apt::source { 'nodejs_10.x':
-    location => "http://apt.uitdatabank.be/nodejs_10.x-${environment}",
-    release  => 'trusty',
-    repos    => 'main'
+    ensure => 'absent'
   }
 
   @apt::source { 'nodejs_12.x':
-    location => "http://apt.uitdatabank.be/nodejs_12.x-${environment}",
-    release  => $facts['os']['distro']['codename'],
-    repos    => 'main'
+    ensure => 'absent'
   }
 
   @apt::source { 'nodejs_14.x':
-    location => "http://apt.uitdatabank.be/nodejs_14.x-${environment}",
-    release  => $facts['os']['distro']['codename'],
-    repos    => 'main'
+    ensure => 'absent'
   }
 
   @apt::source { 'nodejs_16.x':
-    location => "http://apt.uitdatabank.be/nodejs_16.x-${environment}",
-    release  => 'xenial',
-    repos    => 'main'
+    ensure => 'absent'
   }
 
   @apt::source { 'elasticsearch':
@@ -238,9 +230,7 @@ class profiles::apt::repositories {
   }
 
   @apt::source { 'nodejs_16':
-    location => "https://apt.publiq.be/nodejs_16-${environment}",
-    release  => $facts['os']['distro']['codename'],
-    repos    => 'main'
+    ensure   => 'absent'
   }
 
   @apt::source { 'publiq-nodejs-14':

--- a/manifests/nodejs.pp
+++ b/manifests/nodejs.pp
@@ -4,6 +4,12 @@ class profiles::nodejs (
 
   $major_version = split($version, /\./)[0]
 
+  realize Apt::Source[nodejs_10.x]
+  realize Apt::Source[nodejs_12.x]
+  realize Apt::Source[nodejs_14.x]
+  realize Apt::Source[nodejs_16.x]
+  realize Apt::Source[nodejs_16]
+
   realize Apt::Source["publiq-nodejs-${major_version}"]
   realize Apt::Source['yarn']
 

--- a/manifests/nodejs.pp
+++ b/manifests/nodejs.pp
@@ -4,11 +4,11 @@ class profiles::nodejs (
 
   $major_version = split($version, /\./)[0]
 
-  realize Apt::Source[nodejs_10.x]
-  realize Apt::Source[nodejs_12.x]
-  realize Apt::Source[nodejs_14.x]
-  realize Apt::Source[nodejs_16.x]
-  realize Apt::Source[nodejs_16]
+  realize Apt::Source['nodejs_10.x']
+  realize Apt::Source['nodejs_12.x']
+  realize Apt::Source['nodejs_14.x']
+  realize Apt::Source['nodejs_16.x']
+  realize Apt::Source['nodejs_16']
 
   realize Apt::Source["publiq-nodejs-${major_version}"]
   realize Apt::Source['yarn']

--- a/spec/classes/apt/repositories_spec.rb
+++ b/spec/classes/apt/repositories_spec.rb
@@ -30,9 +30,6 @@ describe 'profiles::apt::repositories' do
 
         include_examples 'apt repositories', 'cultuurnet-tools'
         include_examples 'apt repositories', 'rabbitmq'
-        include_examples 'apt repositories', 'nodejs_10.x'
-        include_examples 'apt repositories', 'nodejs_12.x'
-        include_examples 'apt repositories', 'nodejs_14.x'
         include_examples 'apt repositories', 'elasticsearch'
         include_examples 'apt repositories', 'yarn'
         include_examples 'apt repositories', 'erlang'
@@ -68,24 +65,6 @@ describe 'profiles::apt::repositories' do
               'location' => 'http://apt.uitdatabank.be/rabbitmq-testing',
               'repos'    => 'main',
               'release'  => 'testing'
-            ) }
-
-            it { is_expected.to contain_apt__source('nodejs_10.x').with(
-              'location' => 'http://apt.uitdatabank.be/nodejs_10.x-testing',
-              'repos'    => 'main',
-              'release'  => 'trusty'
-            ) }
-
-            it { is_expected.to contain_apt__source('nodejs_12.x').with(
-              'location' => 'http://apt.uitdatabank.be/nodejs_12.x-testing',
-              'repos'    => 'main',
-              'release'  => 'trusty'
-            ) }
-
-            it { is_expected.to contain_apt__source('nodejs_14.x').with(
-              'location' => 'http://apt.uitdatabank.be/nodejs_14.x-testing',
-              'repos'    => 'main',
-              'release'  => 'trusty'
             ) }
 
             it { is_expected.to contain_apt__source('elasticsearch').with(
@@ -167,24 +146,6 @@ describe 'profiles::apt::repositories' do
               'release'  => 'testing'
             ) }
 
-            it { is_expected.to contain_apt__source('nodejs_10.x').with(
-              'location' => 'http://apt.uitdatabank.be/nodejs_10.x-acceptance',
-              'repos'    => 'main',
-              'release'  => 'trusty'
-            ) }
-
-            it { is_expected.to contain_apt__source('nodejs_12.x').with(
-              'location' => 'http://apt.uitdatabank.be/nodejs_12.x-acceptance',
-              'repos'    => 'main',
-              'release'  => 'xenial'
-            ) }
-
-            it { is_expected.to contain_apt__source('nodejs_14.x').with(
-              'location' => 'http://apt.uitdatabank.be/nodejs_14.x-acceptance',
-              'repos'    => 'main',
-              'release'  => 'xenial'
-            ) }
-
             it { is_expected.to contain_apt__source('elasticsearch').with(
               'location' => 'http://apt.uitdatabank.be/elasticsearch-acceptance',
               'repos'    => 'main',
@@ -207,17 +168,6 @@ describe 'profiles::apt::repositories' do
               'location' => 'http://apt.uitdatabank.be/jenkins-acceptance',
               'repos'    => 'main',
               'release'  => 'xenial'
-            ) }
-
-            it { is_expected.to contain_apt__source('nodejs_16.x').with(
-              'location' => 'http://apt.uitdatabank.be/nodejs_16.x-acceptance',
-              'ensure'   => 'present',
-              'repos'    => 'main',
-              'include'  => {
-                'deb' => 'true',
-                'src' => 'false'
-              },
-              'release' => 'xenial'
             ) }
 
             it { is_expected.to contain_apt__source('docker').with(
@@ -399,17 +349,6 @@ describe 'profiles::apt::repositories' do
 
             it { is_expected.to contain_apt__source('elastic-8.x').with(
               'location'     => 'https://apt.publiq.be/elastic-8.x-acceptance',
-              'ensure'       => 'present',
-              'repos'        => 'main',
-              'include'      => {
-                'deb' => 'true',
-                'src' => 'false'
-              },
-              'release'      => 'xenial'
-            ) }
-
-            it { is_expected.to contain_apt__source('nodejs_16').with(
-              'location'     => 'https://apt.publiq.be/nodejs_16-acceptance',
               'ensure'       => 'present',
               'repos'        => 'main',
               'include'      => {


### PR DESCRIPTION
### Changed

- Make sure old nodejs repository definitions are unavailable on the hosts (afterwards the definition can be removed alltogether)

---
Ticket: https://jira.uitdatabank.be/browse/OPS-896
