### PR TITLE
Remove unused cultuurnet-search apt repository

### DIFF
--- a/manifests/deployment/repositories.pp
+++ b/manifests/deployment/repositories.pp
@@ -19,8 +19,4 @@ class profiles::deployment::repositories {
   @apt::source { 'publiq-uitpasbe':
     location => "http://apt.uitdatabank.be/uitpas.be-${environment}"
   }
-
-  @apt::source { 'cultuurnet-search':
-    location => "http://apt.uitdatabank.be/search-${environment}"
-  }
 }

--- a/manifests/udb3/search.pp
+++ b/manifests/udb3/search.pp
@@ -18,8 +18,6 @@ class profiles::udb3::search (
   # TODO: solution for certificates/HTTPS vhosts
   # TODO: firewall rules
 
-  realize Apt::Source['cultuurnet-search']
-
   if $facts['ec2_metadata'] {
     $http_hosts = [ $facts['ipaddress_eth0'], '127.0.0.1']
   } else {
@@ -43,5 +41,4 @@ class profiles::udb3::search (
 
   Class['profiles::elasticsearch'] -> Elasticsearch::Instance['es01']
   Elasticsearch::Instance['es01'] -> Class['deployment::udb3::search']
-  Apt::Source['cultuurnet-search'] -> Class['deployment::udb3::search']
 }

--- a/spec/classes/deployment/repositories_spec.rb
+++ b/spec/classes/deployment/repositories_spec.rb
@@ -30,7 +30,6 @@ describe 'profiles::deployment::repositories' do
 
         include_examples 'deployment repositories', 'publiq-uitidv2'
         include_examples 'deployment repositories', 'publiq-uitpasbe'
-        include_examples 'deployment repositories', 'cultuurnet-search'
 
         case facts[:os]['release']['major']
         when '14.04'
@@ -46,11 +45,6 @@ describe 'profiles::deployment::repositories' do
               'location' => 'http://apt.uitdatabank.be/uitpas.be-testing',
               'release'  => 'trusty'
             ) }
-
-            it { is_expected.to contain_apt__source('cultuurnet-search').with(
-              'location' => 'http://apt.uitdatabank.be/search-testing',
-              'release'  => 'trusty'
-            ) }
           end
 
         when '16.04'
@@ -64,11 +58,6 @@ describe 'profiles::deployment::repositories' do
 
             it { is_expected.to contain_apt__source('publiq-uitpasbe').with(
               'location' => 'http://apt.uitdatabank.be/uitpas.be-acceptance',
-              'release'  => 'xenial'
-            ) }
-
-            it { is_expected.to contain_apt__source('cultuurnet-search').with(
-              'location' => 'http://apt.uitdatabank.be/search-acceptance',
               'release'  => 'xenial'
             ) }
           end


### PR DESCRIPTION
### Removed

- Unused cultuurnet-search apt repository

---
Ticket: https://jira.uitdatabank.be/browse/III-4993
