### PR TITLE
Add environment to main section of puppet.conf on EC2 machines

### DIFF
--- a/manifests/puppet/agent.pp
+++ b/manifests/puppet/agent.pp
@@ -35,7 +35,7 @@ class profiles::puppet::agent (
       *       => $default_ini_setting_attributes
     }
 
-    ini_setting { 'environment':
+    ini_setting { 'global environment':
       ensure  => 'absent',
       setting => 'environment',
       section => '',

--- a/manifests/puppet/agent.pp
+++ b/manifests/puppet/agent.pp
@@ -27,6 +27,23 @@ class profiles::puppet::agent (
     }
   }
 
+  if $facts['ec2_metadata'] {
+    ini_setting { 'environment':
+      setting => 'environment',
+      section => 'main',
+      value   => $facts['ec2_tags']['environment'],
+      *       => $default_ini_setting_attributes
+    }
+
+    ini_setting { 'environment':
+      ensure  => 'absent',
+      setting => 'environment',
+      section => '',
+      path    => '/etc/puppetlabs/puppet/puppet.conf',
+      notify  => Service['puppet']
+    }
+  }
+
   ini_setting { 'agent certificate_revocation':
     setting => 'certificate_revocation',
     section => 'agent',

--- a/spec/classes/puppet/agent_spec.rb
+++ b/spec/classes/puppet/agent_spec.rb
@@ -24,8 +24,7 @@ describe 'profiles::puppet::agent' do
           'ensure'    => 'stopped',
           'enable'    => false,
           'hasstatus' => true
-          )
-        }
+        ) }
 
         it { is_expected.to contain_ini_setting('agent certificate_revocation').with(
           'ensure'  => 'present',
@@ -33,8 +32,7 @@ describe 'profiles::puppet::agent' do
           'section' => 'agent',
           'setting' => 'certificate_revocation',
           'value'   => false
-          )
-        }
+        ) }
 
         it { is_expected.to contain_ini_setting('agent usecacheonfailure').with(
           'ensure'  => 'present',
@@ -42,8 +40,7 @@ describe 'profiles::puppet::agent' do
           'section' => 'agent',
           'setting' => 'usecacheonfailure',
           'value'   => false
-          )
-        }
+        ) }
 
         it { is_expected.to contain_ini_setting('agent preferred_serialization_format').with(
           'ensure'  => 'present',
@@ -51,8 +48,7 @@ describe 'profiles::puppet::agent' do
           'section' => 'agent',
           'setting' => 'preferred_serialization_format',
           'value'   => 'pson'
-          )
-        }
+        ) }
 
         it { is_expected.to contain_ini_setting('agent certificate_revocation').that_notifies('Service[puppet]') }
         it { is_expected.to contain_ini_setting('agent usecacheonfailure').that_notifies('Service[puppet]') }
@@ -72,8 +68,7 @@ describe 'profiles::puppet::agent' do
           'ensure'    => 'running',
           'enable'    => true,
           'hasstatus' => true
-          )
-        }
+        ) }
 
         it { is_expected.to contain_ini_setting('puppetserver').with(
           'ensure'  => 'present',
@@ -81,10 +76,49 @@ describe 'profiles::puppet::agent' do
           'section' => 'main',
           'setting' => 'server',
           'value'   => 'puppet.example.com'
-          )
-        }
+        ) }
 
         it { is_expected.to contain_ini_setting('puppetserver').that_notifies('Service[puppet]') }
+      end
+
+      context "on AWS EC2" do
+        let(:facts) do
+          super().merge({ 'ec2_metadata' => 'true'})
+        end
+
+        context "with EC2 tag 'Environment => acceptance'" do
+          let(:facts) do
+            super().merge({ 'ec2_tags' => {'environment' => 'acceptance'} })
+          end
+
+          it { is_expected.to contain_ini_setting('environment').with(
+            'ensure'  => 'present',
+            'path'    => '/etc/puppetlabs/puppet/puppet.conf',
+            'section' => 'main',
+            'setting' => 'environment',
+            'value'   => 'acceptance'
+          ) }
+
+          it { is_expected.to contain_ini_setting('environment').that_notifies('Service[puppet]') }
+        end
+
+        context "with EC2 tag 'Environment => production'" do
+          let(:facts) do
+            super().merge({ 'ec2_tags' => {'environment' => 'production'} })
+          end
+
+          it { is_expected.to contain_ini_setting('environment').with(
+            'value' => 'production'
+          ) }
+        end
+      end
+
+      context "not on AWS EC2" do
+        let(:facts) do
+          super()
+        end
+
+        it { is_expected.not_to contain_ini_setting('environment') }
       end
     end
   end


### PR DESCRIPTION
### Added

- environment setting in main section of puppet.conf for EC2 machines
