### PR TITLE
Fix deprecation warnings for Ubuntu 18.04 and NodeJS 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
### Changed

- Github actions operating system
- Github actions checkout action