### PR TITLE
Lookup puppetdb_url in hieradata under data::puppet::puppetdb::url

### DIFF
--- a/manifests/curator.pp
+++ b/manifests/curator.pp
@@ -6,7 +6,6 @@ class profiles::curator (
   Boolean          $articlelinker_service_manage      = true,
   String           $articlelinker_service_ensure      = 'running',
   Boolean          $articlelinker_service_enable      = true,
-  Optional[String] $puppetdb_url                      = undef
 ) inherits ::profiles {
 
   # TODO: unit tests
@@ -28,8 +27,7 @@ class profiles::curator (
       env_defaults_source => $articlelinker_env_defaults_source,
       service_manage      => $articlelinker_service_manage,
       service_ensure      => $articlelinker_service_ensure,
-      service_enable      => $articlelinker_service_enable,
-      puppetdb_url        => $puppetdb_url
+      service_enable      => $articlelinker_service_enable
     }
   }
 }

--- a/manifests/deployment/curator/api.pp
+++ b/manifests/deployment/curator/api.pp
@@ -1,7 +1,7 @@
 class profiles::deployment::curator::api (
   String           $config_source,
   String           $version        = 'latest',
-  Optional[String] $puppetdb_url   = undef
+  Optional[String] $puppetdb_url   = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   $basedir = '/var/www/curator-api'

--- a/manifests/deployment/curator/articlelinker.pp
+++ b/manifests/deployment/curator/articlelinker.pp
@@ -6,7 +6,7 @@ class profiles::deployment::curator::articlelinker (
   Boolean          $service_manage      = true,
   String           $service_ensure      = 'running',
   Boolean          $service_enable      = true,
-  Optional[String] $puppetdb_url        = undef
+  Optional[String] $puppetdb_url        = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   $basedir = '/var/www/curator-articlelinker'

--- a/manifests/deployment/mspotm/backend.pp
+++ b/manifests/deployment/mspotm/backend.pp
@@ -1,7 +1,7 @@
 class profiles::deployment::mspotm::backend (
   String           $config_source,
   String           $version        = 'latest',
-  Optional[String] $puppetdb_url   = undef
+  Optional[String] $puppetdb_url   = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   $basedir = '/var/www/mspotm-api'

--- a/manifests/deployment/uit/api.pp
+++ b/manifests/deployment/uit/api.pp
@@ -5,7 +5,7 @@ class profiles::deployment::uit::api (
   String           $service_ensure          = 'running',
   Boolean          $service_enable          = true,
   Optional[String] $service_defaults_source = undef,
-  Optional[String] $puppetdb_url            = undef
+  Optional[String] $puppetdb_url            = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   $basedir = '/var/www/uit-api'

--- a/manifests/deployment/uit/cms.pp
+++ b/manifests/deployment/uit/cms.pp
@@ -2,10 +2,10 @@ class profiles::deployment::uit::cms (
   String           $settings_source,
   String           $hostnames_source,
   String           $drush_config_source,
-  String           $version              = 'latest',
-  Optional[String] $database_version     = undef,
-  Optional[String] $files_version        = undef,
-  Optional[String] $puppetdb_url         = undef
+  String           $version             = 'latest',
+  Optional[String] $database_version    = undef,
+  Optional[String] $files_version       = undef,
+  Optional[String] $puppetdb_url        = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   $basedir = '/var/www/uit-cms'

--- a/manifests/deployment/uit/frontend.pp
+++ b/manifests/deployment/uit/frontend.pp
@@ -8,7 +8,7 @@ class profiles::deployment::uit::frontend (
   Optional[String] $service_defaults_source = undef,
   Optional[String] $maintenance_source      = undef,
   Optional[String] $deployment_source       = undef,
-  Optional[String] $puppetdb_url            = undef
+  Optional[String] $puppetdb_url            = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   $basedir = '/var/www/uit-frontend/packages/app'

--- a/manifests/deployment/uit/notifications.pp
+++ b/manifests/deployment/uit/notifications.pp
@@ -2,8 +2,8 @@ class profiles::deployment::uit::notifications (
   String           $settings_source,
   String           $aws_access_key_id,
   String           $aws_secret_access_key,
-  String           $version          = 'latest',
-  Optional[String] $puppetdb_url     = undef
+  String           $version               = 'latest',
+  Optional[String] $puppetdb_url          = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   $basedir = '/var/www/uit-notifications'

--- a/manifests/deployment/uitidv2/backend.pp
+++ b/manifests/deployment/uitidv2/backend.pp
@@ -5,7 +5,7 @@ class profiles::deployment::uitidv2::backend (
   Boolean          $service_manage      = true,
   String           $service_ensure      = 'running',
   Boolean          $service_enable      = true,
-  Optional[String] $puppetdb_url        = undef
+  Optional[String] $puppetdb_url        = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   $basedir = '/var/www/uitid-api'

--- a/manifests/deployment/uitidv2/frontend.pp
+++ b/manifests/deployment/uitidv2/frontend.pp
@@ -5,7 +5,7 @@ class profiles::deployment::uitidv2::frontend (
   Boolean          $service_manage      = true,
   String           $service_ensure      = 'running',
   Boolean          $service_enable      = true,
-  Optional[String] $puppetdb_url        = undef
+  Optional[String] $puppetdb_url        = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   $basedir = '/var/www/uitid-frontend/app'

--- a/manifests/deployment/uitpas_be/backend.pp
+++ b/manifests/deployment/uitpas_be/backend.pp
@@ -1,7 +1,7 @@
 class profiles::deployment::uitpas_be::backend (
   String           $config_source,
   String           $version        = 'latest',
-  Optional[String] $puppetdb_url   = undef
+  Optional[String] $puppetdb_url   = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   $basedir = '/var/www/uitpas-website-api'

--- a/manifests/deployment/uitpas_be/frontend.pp
+++ b/manifests/deployment/uitpas_be/frontend.pp
@@ -5,7 +5,7 @@ class profiles::deployment::uitpas_be::frontend (
   Boolean          $service_manage      = true,
   String           $service_ensure      = 'running',
   Boolean          $service_enable      = true,
-  Optional[String] $puppetdb_url        = undef
+  Optional[String] $puppetdb_url        = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   $basedir = '/var/www/uitpas-website-frontend'

--- a/manifests/publiq/appconfig/deployment.pp
+++ b/manifests/publiq/appconfig/deployment.pp
@@ -1,6 +1,6 @@
 class profiles::publiq::appconfig::deployment (
   String           $version      = 'latest',
-  Optional[String] $puppetdb_url = undef
+  Optional[String] $puppetdb_url = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   include ::profiles::puppetserver::cache_clear

--- a/manifests/publiq/infrastructure/deployment.pp
+++ b/manifests/publiq/infrastructure/deployment.pp
@@ -1,6 +1,6 @@
 class profiles::publiq::infrastructure::deployment (
   String           $version      = 'latest',
-  Optional[String] $puppetdb_url = undef
+  Optional[String] $puppetdb_url = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   include ::profiles::puppetserver::cache_clear

--- a/manifests/publiq/prototypes/deployment.pp
+++ b/manifests/publiq/prototypes/deployment.pp
@@ -1,6 +1,6 @@
 class profiles::publiq::prototypes::deployment (
   String           $version      = 'latest',
-  Optional[String] $puppetdb_url = undef
+  Optional[String] $puppetdb_url = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   realize Apt::Source['publiq-prototypes']

--- a/manifests/publiq/versions/deployment.pp
+++ b/manifests/publiq/versions/deployment.pp
@@ -4,7 +4,7 @@ class profiles::publiq::versions::deployment (
   Stdlib::Port::Unprivileged $service_port    = lookup('profiles::publiq::versions::service_port', Stdlib::Port::Unprivileged, 'first', 3000),
   Optional[String]           $certificate     = undef,
   Optional[String]           $private_key     = undef,
-  Optional[String]           $puppetdb_url    = undef
+  Optional[String]           $puppetdb_url    = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   realize Apt::Source['publiq-versions']

--- a/manifests/uit/mail_subscriptions/deployment.pp
+++ b/manifests/uit/mail_subscriptions/deployment.pp
@@ -5,7 +5,7 @@ class profiles::uit::mail_subscriptions::deployment (
   String           $service_ensure          = 'running',
   Boolean          $service_enable          = true,
   Optional[String] $service_defaults_source = undef,
-  Optional[String] $puppetdb_url            = undef
+  Optional[String] $puppetdb_url            = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   $basedir = '/var/www/uit-mail-subscriptions'

--- a/manifests/uit/recommender_frontend/deployment.pp
+++ b/manifests/uit/recommender_frontend/deployment.pp
@@ -5,7 +5,7 @@ class profiles::uit::recommender_frontend::deployment (
   String           $service_ensure          = 'running',
   Boolean          $service_enable          = true,
   Optional[String] $service_defaults_source = undef,
-  Optional[String] $puppetdb_url            = undef
+  Optional[String] $puppetdb_url            = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   $basedir = '/var/www/uit-recommender-frontend'

--- a/spec/classes/curator_spec.rb
+++ b/spec/classes/curator_spec.rb
@@ -31,8 +31,7 @@ describe 'profiles::curator' do
           'env_defaults_source' => '/defaults',
           'service_manage'      => true,
           'service_ensure'      => 'running',
-          'service_enable'      => true,
-          'puppetdb_url'        => nil
+          'service_enable'      => true
         ) }
 
         context "with articlelinker_service_manage => false, articlelinker_service_ensure => stopped and articlelinker_service_enable => false" do
@@ -51,22 +50,19 @@ describe 'profiles::curator' do
             'env_defaults_source' => '/defaults',
             'service_manage'      => false,
             'service_ensure'      => 'stopped',
-            'service_enable'      => false,
-            'puppetdb_url'        => nil
+            'service_enable'      => false
           ) }
         end
 
-        context "with articlelinker_version => 9.8.7 and puppetdb_url => http://localhost:8080" do
+        context "with articlelinker_version => 9.8.7" do
           let(:params) {
             super().merge({
-              'articlelinker_version' => '9.8.7',
-              'puppetdb_url'          => 'http://localhost:8080'
+              'articlelinker_version' => '9.8.7'
             } )
           }
 
           it { is_expected.to contain_class('profiles::deployment::curator::articlelinker').with(
-            'version'      => '9.8.7',
-            'puppetdb_url' => 'http://localhost:8080'
+            'version'      => '9.8.7'
           ) }
         end
       end

--- a/spec/classes/deployment/curator/articlelinker_spec.rb
+++ b/spec/classes/deployment/curator/articlelinker_spec.rb
@@ -54,9 +54,21 @@ describe 'profiles::deployment::curator::articlelinker' do
         it { is_expected.to contain_file('curator-articlelinker-config').that_notifies('Service[curator-articlelinker]') }
         it { is_expected.to contain_file('curator-articlelinker-publishers').that_notifies('Service[curator-articlelinker]') }
 
-        it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::curator::articlelinker').with(
-          'puppetdb_url' => nil
-        ) }
+        context "without hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::curator::articlelinker').with(
+            'puppetdb_url' => nil
+          ) }
+        end
+
+        context "with hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::curator::articlelinker').with(
+            'puppetdb_url' => 'http://localhost:8081'
+          ) }
+        end
 
         context "with service_manage => false" do
           let(:params) {

--- a/spec/classes/deployment/mspotm/backend_spec.rb
+++ b/spec/classes/deployment/mspotm/backend_spec.rb
@@ -56,9 +56,21 @@ describe 'profiles::deployment::mspotm::backend' do
         it { is_expected.to contain_exec('run mspotm database migrations').that_subscribes_to('Package[mspotm-api]') }
         it { is_expected.to contain_exec('run mspotm database migrations').that_requires('File[mspotm-backend-config]') }
 
-        it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::mspotm::backend').with(
-          'puppetdb_url' => nil
-        ) }
+        context "without hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::mspotm::backend').with(
+            'puppetdb_url' => nil
+          ) }
+        end
+
+        context "with hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::mspotm::backend').with(
+            'puppetdb_url' => 'http://localhost:8081'
+          ) }
+        end
       end
 
       context "with config_source => /bar, version => 1.2.3 and puppetdb_url => http://example.com:8000" do

--- a/spec/classes/deployment/uit/api_spec.rb
+++ b/spec/classes/deployment/uit/api_spec.rb
@@ -86,9 +86,21 @@ describe 'profiles::deployment::uit::api' do
         it { is_expected.to contain_service('uit-api').that_requires('File[uit-api-log]') }
         it { is_expected.to contain_file('uit-api-config-graphql').that_notifies('Service[uit-api]') }
 
-        it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uit::api').with(
-          'puppetdb_url' => nil
-        ) }
+        context "without hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uit::api').with(
+            'puppetdb_url' => nil
+          ) }
+        end
+
+        context "with hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uit::api').with(
+            'puppetdb_url' => 'http://localhost:8081'
+          ) }
+        end
 
         context "with service_manage => false" do
           let(:params) {

--- a/spec/classes/deployment/uit/cms_spec.rb
+++ b/spec/classes/deployment/uit/cms_spec.rb
@@ -24,10 +24,21 @@ describe 'profiles::deployment::uit::cms' do
           'source' => '/abc'
         ) }
 
-        it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uit::cms').with(
-          'puppetdb_url' => nil
-        ) }
+        context "without hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
 
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uit::cms').with(
+            'puppetdb_url' => nil
+          ) }
+        end
+
+        context "with hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uit::cms').with(
+            'puppetdb_url' => 'http://localhost:8081'
+          ) }
+        end
       end
     end
   end

--- a/spec/classes/deployment/uit/frontend_spec.rb
+++ b/spec/classes/deployment/uit/frontend_spec.rb
@@ -41,9 +41,21 @@ describe 'profiles::deployment::uit::frontend' do
         it { is_expected.to contain_service('uit-frontend').that_requires('Package[uit-frontend]') }
         it { is_expected.to contain_file('uit-frontend-config').that_notifies('Service[uit-frontend]') }
 
-        it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uit::frontend').with(
-          'puppetdb_url' => nil
-        ) }
+        context "without hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uit::frontend').with(
+            'puppetdb_url' => nil
+          ) }
+        end
+
+        context "with hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uit::frontend').with(
+            'puppetdb_url' => 'http://localhost:8081'
+          ) }
+        end
 
         context "with service_manage => false" do
           let(:params) {

--- a/spec/classes/deployment/uit/notifications_spec.rb
+++ b/spec/classes/deployment/uit/notifications_spec.rb
@@ -34,9 +34,21 @@ describe 'profiles::deployment::uit::notifications' do
 
         it { is_expected.not_to contain_file('/etc/default/uit-notifications') }
 
-        it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uit::notifications').with(
-          'puppetdb_url' => nil
-        ) }
+        context "without hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uit::notifications').with(
+            'puppetdb_url' => nil
+          ) }
+        end
+
+        context "with hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uit::notifications').with(
+            'puppetdb_url' => 'http://localhost:8081'
+          ) }
+        end
       end
     end
   end

--- a/spec/classes/deployment/uitidv2/backend_spec.rb
+++ b/spec/classes/deployment/uitidv2/backend_spec.rb
@@ -41,9 +41,21 @@ describe 'profiles::deployment::uitidv2::backend' do
         it { is_expected.to contain_service('uitid-api').that_requires('Package[uitid-api]') }
         it { is_expected.to contain_file('uitid-api-config').that_notifies('Service[uitid-api]') }
 
-        it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uitidv2::backend').with(
-          'puppetdb_url' => nil
-        ) }
+        context "without hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uitidv2::backend').with(
+            'puppetdb_url' => nil
+          ) }
+        end
+
+        context "with hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uitidv2::backend').with(
+            'puppetdb_url' => 'http://localhost:8081'
+          ) }
+        end
 
         context "with service_manage => false" do
           let(:params) {

--- a/spec/classes/deployment/uitidv2/frontend_spec.rb
+++ b/spec/classes/deployment/uitidv2/frontend_spec.rb
@@ -41,9 +41,21 @@ describe 'profiles::deployment::uitidv2::frontend' do
         it { is_expected.to contain_service('uitid-frontend').that_requires('Package[uitid-frontend]') }
         it { is_expected.to contain_file('uitid-frontend-config').that_notifies('Service[uitid-frontend]') }
 
-        it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uitidv2::frontend').with(
-          'puppetdb_url' => nil
-        ) }
+        context "without hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uitidv2::frontend').with(
+            'puppetdb_url' => nil
+          ) }
+        end
+
+        context "with hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uitidv2::frontend').with(
+            'puppetdb_url' => 'http://localhost:8081'
+          ) }
+        end
 
         context "with service_manage => false" do
           let(:params) {

--- a/spec/classes/deployment/uitpas_be/backend_spec.rb
+++ b/spec/classes/deployment/uitpas_be/backend_spec.rb
@@ -41,9 +41,21 @@ describe 'profiles::deployment::uitpas_be::backend' do
 
         it { is_expected.to contain_exec('uitpasbe-backend_cache_clear').that_subscribes_to('Package[uitpas-website-api]') }
 
-        it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uitpas_be::backend').with(
-          'puppetdb_url' => nil
-        ) }
+        context "without hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uitpas_be::backend').with(
+            'puppetdb_url' => nil
+          ) }
+        end
+
+        context "with hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uitpas_be::backend').with(
+            'puppetdb_url' => 'http://localhost:8081'
+          ) }
+        end
       end
     end
   end

--- a/spec/classes/deployment/uitpas_be/frontend_spec.rb
+++ b/spec/classes/deployment/uitpas_be/frontend_spec.rb
@@ -41,9 +41,21 @@ describe 'profiles::deployment::uitpas_be::frontend' do
         it { is_expected.to contain_service('uitpas-website-frontend').that_requires('Package[uitpas-website-frontend]') }
         it { is_expected.to contain_file('uitpas-website-frontend-config').that_notifies('Service[uitpas-website-frontend]') }
 
-        it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uitpas_be::frontend').with(
-          'puppetdb_url' => nil
-        ) }
+        context "without hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uitpas_be::frontend').with(
+            'puppetdb_url' => nil
+          ) }
+        end
+
+        context "with hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::deployment::uitpas_be::frontend').with(
+            'puppetdb_url' => 'http://localhost:8081'
+          ) }
+        end
 
         context "with service_manage => false" do
           let(:params) {

--- a/spec/classes/publiq/appconfig/deployment_spec.rb
+++ b/spec/classes/publiq/appconfig/deployment_spec.rb
@@ -20,9 +20,21 @@ describe 'profiles::publiq::appconfig::deployment' do
           'ensure' => 'latest'
         ) }
 
-        it { is_expected.to contain_profiles__deployment__versions('profiles::publiq::appconfig::deployment').with(
-          'puppetdb_url' => nil
-        ) }
+        context "without hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::publiq::appconfig::deployment').with(
+            'puppetdb_url' => nil
+          ) }
+        end
+
+        context "with hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::publiq::appconfig::deployment').with(
+            'puppetdb_url' => 'http://localhost:8081'
+          ) }
+        end
 
         it { is_expected.to contain_package('publiq-appconfig').that_requires('Apt::Source[publiq-appconfig]') }
         it { is_expected.to contain_package('publiq-appconfig').that_notifies('Class[profiles::puppetserver::cache_clear]') }

--- a/spec/classes/publiq/infrastructure/deployment_spec.rb
+++ b/spec/classes/publiq/infrastructure/deployment_spec.rb
@@ -20,9 +20,21 @@ describe 'profiles::publiq::infrastructure::deployment' do
           'ensure' => 'latest'
         ) }
 
-        it { is_expected.to contain_profiles__deployment__versions('profiles::publiq::infrastructure::deployment').with(
-          'puppetdb_url' => nil
-        ) }
+        context "without hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::publiq::infrastructure::deployment').with(
+            'puppetdb_url' => nil
+          ) }
+        end
+
+        context "with hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::publiq::infrastructure::deployment').with(
+            'puppetdb_url' => 'http://localhost:8081'
+          ) }
+        end
 
         it { is_expected.to contain_package('publiq-infrastructure').that_requires('Apt::Source[publiq-infrastructure]') }
         it { is_expected.to contain_package('publiq-infrastructure').that_notifies('Class[profiles::puppetserver::cache_clear]') }

--- a/spec/classes/publiq/prototypes/deployment_spec.rb
+++ b/spec/classes/publiq/prototypes/deployment_spec.rb
@@ -7,43 +7,33 @@ describe 'profiles::publiq::prototypes::deployment' do
    context "on #{os}" do
       let(:facts) { facts }
 
-      it { is_expected.to compile.with_all_deps }
-
-      it { is_expected.to contain_class('profiles::apt::keys') }
-
-      it { is_expected.to contain_apt__source('publiq-prototypes') }
-
-      it { is_expected.to contain_profiles__deployment__versions('profiles::publiq::prototypes::deployment').with(
-        'puppetdb_url'    => nil
-      ) }
-
-      it { is_expected.to contain_apt__source('publiq-prototypes').that_requires('Class[profiles::apt::keys]') }
-      it { is_expected.to contain_package('publiq-prototypes').that_requires('Apt::Source[publiq-prototypes]') }
-
-      it { is_expected.to contain_package('publiq-prototypes').that_notifies('Profiles::Deployment::Versions[profiles::publiq::prototypes::deployment]') }
-
-      case facts[:os]['release']['major']
-      when '14.04'
-        let(:facts) { facts }
-
-        it { is_expected.to contain_apt__source('publiq-prototypes').with(
-          'release' => 'trusty'
-        ) }
-
-      when '16.04'
-        let(:facts) { facts }
-
-        it { is_expected.to contain_apt__source('publiq-prototypes').with(
-          'release' => 'xenial'
-        ) }
-      end
-
       context "without parameters" do
         let(:params) { {} }
+
+        it { is_expected.to compile.with_all_deps }
 
         it { is_expected.to contain_package('publiq-prototypes').with(
           'ensure' => 'latest'
         ) }
+
+        context "without hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::publiq::prototypes::deployment').with(
+            'puppetdb_url' => nil
+          ) }
+        end
+
+        context "with hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::publiq::prototypes::deployment').with(
+            'puppetdb_url' => 'http://localhost:8081'
+          ) }
+        end
+
+        it { is_expected.to contain_package('publiq-prototypes').that_requires('Apt::Source[publiq-prototypes]') }
+        it { is_expected.to contain_package('publiq-prototypes').that_notifies('Profiles::Deployment::Versions[profiles::publiq::prototypes::deployment]') }
       end
 
       context "with version => 1.2.3 and puppetdb_url => http://example.com:8000" do

--- a/spec/classes/publiq/versions/deployment_spec.rb
+++ b/spec/classes/publiq/versions/deployment_spec.rb
@@ -67,6 +67,10 @@ describe 'profiles::publiq::versions::deployment' do
 
           it { is_expected.to contain_file('publiq-versions-service-defaults').with_content(/^LISTEN_ADDRESS=127\.0\.1\.1$/) }
           it { is_expected.to contain_file('publiq-versions-service-defaults').with_content(/^LISTEN_PORT=6000$/) }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::publiq::versions::deployment').with(
+            'puppetdb_url' => 'http://localhost:8081'
+          ) }
         end
       end
 

--- a/spec/classes/uit/mail_subscriptions/deployment_spec.rb
+++ b/spec/classes/uit/mail_subscriptions/deployment_spec.rb
@@ -43,9 +43,21 @@ describe 'profiles::uit::mail_subscriptions::deployment' do
         it { is_expected.to contain_service('uit-mail-subscriptions').that_requires('Package[uit-mail-subscriptions]') }
         it { is_expected.to contain_file('uit-mail-subscriptions-config').that_notifies('Service[uit-mail-subscriptions]') }
 
-        it { is_expected.to contain_profiles__deployment__versions('profiles::uit::mail_subscriptions::deployment').with(
-          'puppetdb_url' => nil
-        ) }
+        context "without hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::uit::mail_subscriptions::deployment').with(
+            'puppetdb_url' => nil
+          ) }
+        end
+
+        context "with hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::uit::mail_subscriptions::deployment').with(
+            'puppetdb_url' => 'http://localhost:8081'
+          ) }
+        end
 
         context "with service_manage => false" do
           let(:params) {

--- a/spec/classes/uit/recommender_frontend/deployment_spec.rb
+++ b/spec/classes/uit/recommender_frontend/deployment_spec.rb
@@ -41,9 +41,21 @@ describe 'profiles::uit::recommender_frontend::deployment' do
         it { is_expected.to contain_service('uit-recommender-frontend').that_subscribes_to('Package[uit-recommender-frontend]') }
         it { is_expected.to contain_service('uit-recommender-frontend').that_subscribes_to('File[uit-recommender-frontend-config]') }
 
-        it { is_expected.to contain_profiles__deployment__versions('profiles::uit::recommender_frontend::deployment').with(
-          'puppetdb_url' => nil
-        ) }
+        context "without hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::uit::recommender_frontend::deployment').with(
+            'puppetdb_url' => nil
+          ) }
+        end
+
+        context "with hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+          it { is_expected.to contain_profiles__deployment__versions('profiles::uit::recommender_frontend::deployment').with(
+            'puppetdb_url' => 'http://localhost:8081'
+          ) }
+        end
 
         context "with service_defaults_source => '/tmp/service_defaults'" do
           let(:params) {

--- a/spec/support/hiera/data/common.yaml
+++ b/spec/support/hiera/data/common.yaml
@@ -27,3 +27,5 @@ profiles::ssh_authorized_keys::keys:
     tag: 'foobar'
   'acme first key':
     tag: 'acme'
+
+data::puppet::puppetdb::url: 'http://localhost:8081'


### PR DESCRIPTION
### Changed

- Lookup puppetdb_url in hieradata under data::puppet::puppetdb::url by default,
  to avoid having to specify the parameter on every deployment class

---
Ticket: https://jira.uitdatabank.be/browse/OPS-952