### PR TITLE
Move Jenkins repository to apt.publiq.be

### DIFF
--- a/manifests/apt/repositories.pp
+++ b/manifests/apt/repositories.pp
@@ -76,12 +76,6 @@ class profiles::apt::repositories {
     repos    => 'main'
   }
 
-  @apt::source { 'publiq-jenkins':
-    location => "http://apt.uitdatabank.be/jenkins-${environment}",
-    release  => $facts['os']['distro']['codename'],
-    repos    => 'main'
-  }
-
   @apt::source { 'cultuurnet-groepspas':
     location => "http://apt.uitdatabank.be/groepspas-${environment}",
     release  => $facts['os']['distro']['codename'],
@@ -341,6 +335,12 @@ class profiles::apt::repositories {
 
   @apt::source { 'publiq-appconfig':
     location => "https://apt.publiq.be/publiq-appconfig-${environment}",
+    release  => $facts['os']['distro']['codename'],
+    repos    => 'main'
+  }
+
+  @apt::source { 'publiq-jenkins':
+    location => "https://apt.publiq.be/jenkins-${environment}",
     release  => $facts['os']['distro']['codename'],
     repos    => 'main'
   }

--- a/spec/classes/apt/repositories_spec.rb
+++ b/spec/classes/apt/repositories_spec.rb
@@ -86,7 +86,7 @@ describe 'profiles::apt::repositories' do
             ) }
 
             it { is_expected.to contain_apt__source('publiq-jenkins').with(
-              'location' => 'http://apt.uitdatabank.be/jenkins-testing',
+              'location' => 'https://apt.publiq.be/jenkins-testing',
               'repos'    => 'main',
               'release'  => 'trusty'
             ) }
@@ -183,7 +183,7 @@ describe 'profiles::apt::repositories' do
             ) }
 
             it { is_expected.to contain_apt__source('publiq-jenkins').with(
-              'location' => 'http://apt.uitdatabank.be/jenkins-acceptance',
+              'location' => 'https://apt.publiq.be/jenkins-acceptance',
               'repos'    => 'main',
               'release'  => 'xenial'
             ) }


### PR DESCRIPTION
### Changed

- Location of apt repository for Jenkins and derived artifacts