### PR TITLE
[POSTFIX] Allow additional networks to be added to /etc/postfix/mynetworks

### DIFF
--- a/manifests/postfix.pp
+++ b/manifests/postfix.pp
@@ -1,11 +1,12 @@
 class profiles::postfix (
-  Boolean                     $tls              = true,
-  Enum['ipv4', 'ipv6', 'all'] $inet_protocols   = 'all',
-  String                      $listen_addresses = 'all',
-  String                      $relayhost        = '',
-  Boolean                     $aliases          = false,
-  Array[String]               $aliases_domains  = [],
-  String                      $aliases_source   = 'puppet:///modules/profiles/postfix/virtual'
+  Boolean                     $tls                   = true,
+  Enum['ipv4', 'ipv6', 'all'] $inet_protocols        = 'all',
+  String                      $listen_addresses      = 'all',
+  String                      $relayhost             = '',
+  Boolean                     $aliases               = false,
+  Array[String]               $aliases_domains       = [],
+  Array[String]               $additional_mynetworks = [],
+  String                      $aliases_source        = 'puppet:///modules/profiles/postfix/virtual'
 ) inherits ::profiles {
 
   include ::profiles::firewall::rules
@@ -20,6 +21,14 @@ class profiles::postfix (
   if $relayhost == '' {
     $relay_host  = false
     $my_networks = "${config_directory}/mynetworks"
+
+    $additional_mynetworks.each |$mynetwork| {
+      @@concat::fragment { "postfix_additional_network_${mynetwork}":
+        target  => $mynetworks_file,
+        content => "${mynetwork}\n",
+        tag     => 'postfix_mynetworks'
+      }
+    }
 
     Concat::Fragment <<| tag == 'postfix_mynetworks' |>>
 

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -164,7 +164,8 @@ describe 'profiles::postfix' do
           let(:params) {
             super().merge(
               {
-                'aliases' => true
+                'aliases' => true,
+                'additional_mynetworks' => ["5.6.7.8", "9.10.11.12"]
               }
             )
           }
@@ -190,6 +191,20 @@ describe 'profiles::postfix' do
           it { expect(exported_resources).to contain_concat__fragment('postfix_mynetworks_1.2.3.4').with(
             'target'  => '/etc/postfix/mynetworks',
             'content' => "1.2.3.4\n",
+            'tag'     => 'postfix_mynetworks'
+            )
+          }
+
+          it { expect(exported_resources).to contain_concat__fragment('postfix_additional_network_5.6.7.8').with(
+            'target'  => '/etc/postfix/mynetworks',
+            'content' => "5.6.7.8\n",
+            'tag'     => 'postfix_mynetworks'
+            )
+          }
+
+          it { expect(exported_resources).to contain_concat__fragment('postfix_additional_network_9.10.11.12').with(
+            'target'  => '/etc/postfix/mynetworks',
+            'content' => "9.10.11.12\n",
             'tag'     => 'postfix_mynetworks'
             )
           }


### PR DESCRIPTION
this allows us to add ip's or networks to the postfix relay config for systems that are not managed by Puppet.
the code needs array variable `profiles::postfix::additional_mynetworks:` to be defined in Hieradata
