### PR TITLE
The configuration-as-code plugin marks gitSCM as deprecated, use scmGit instead

### DIFF
--- a/templates/jenkins/plugin/git.yaml.erb
+++ b/templates/jenkins/plugin/git.yaml.erb
@@ -1,5 +1,5 @@
 unclassified:
-  gitSCM:
+  scmGit:
     addGitTagAction: false
     allowSecondFetch: false
     createAccountBasedOnEmail: false


### PR DESCRIPTION
### Changed

- gitSCM key replaced by scmGit