### PR TITLE
Make sure yarn repository is absent and use publiq-tools instead

### DIFF
--- a/manifests/apt/repositories.pp
+++ b/manifests/apt/repositories.pp
@@ -93,10 +93,8 @@ class profiles::apt::repositories {
     repos    => 'main'
   }
 
-  @apt::source { 'yarn':
-    location => "http://apt.uitdatabank.be/yarn-${environment}",
-    release  => 'stable',
-    repos    => 'main'
+  apt::source { 'yarn':
+    ensure => 'absent'
   }
 
   @apt::source { 'erlang':

--- a/manifests/deployment/uit/api.pp
+++ b/manifests/deployment/uit/api.pp
@@ -10,7 +10,7 @@ class profiles::deployment::uit::api (
 
   $basedir = '/var/www/uit-api'
 
-  realize Apt::Source['yarn']
+  realize Apt::Source['publiq-tools']
   realize Apt::Source['uit-api']
 
   realize Package['yarn']

--- a/manifests/deployment/uit/notifications.pp
+++ b/manifests/deployment/uit/notifications.pp
@@ -9,6 +9,9 @@ class profiles::deployment::uit::notifications (
   $basedir = '/var/www/uit-notifications'
 
   realize Apt::Source['uit-notifications']
+  realize Apt::Source['publiq-tools']
+
+  realize Package['yarn']
 
   package { 'uit-notifications':
     ensure  => $version,
@@ -26,14 +29,15 @@ class profiles::deployment::uit::notifications (
   }
 
   exec { 'uit-notifications-deploy':
-    command     => '/usr/bin/yarn notifications deploy',
+    command     => 'yarn notifications deploy',
     cwd         => $basedir,
-    path        => [ "${basedir}", '/usr/local/bin', '/usr/bin', '/bin'],
-    environment => [ "AWS_ACCESS_KEY_ID=${aws_access_key_id}", "AWS_SECRET_ACCESS_KEY=${aws_secret_access_key}"],
+    path        => ['/usr/local/bin', '/usr/bin', '/bin', $basedir],
+    environment => ["AWS_ACCESS_KEY_ID=${aws_access_key_id}", "AWS_SECRET_ACCESS_KEY=${aws_secret_access_key}"],
     logoutput   => true,
     user        => 'www-data',
     refreshonly => true,
-    subscribe   => [ Package['uit-notifications'], File['uit-notifications-settings']]
+    subscribe   => [Package['uit-notifications'], File['uit-notifications-settings']],
+    require     => Package['yarn']
   }
 
   profiles::deployment::versions { $title:

--- a/manifests/jenkins/server.pp
+++ b/manifests/jenkins/server.pp
@@ -18,7 +18,7 @@ class profiles::jenkins::server (
 
   realize Apt::Source['publiq-jenkins']
   realize Apt::Source['cultuurnet-tools']
-  realize Apt::Source['yarn']
+  realize Apt::Source['publiq-tools']
 
   class {'::profiles::ruby':
     with_dev => true

--- a/manifests/nodejs.pp
+++ b/manifests/nodejs.pp
@@ -5,7 +5,7 @@ class profiles::nodejs (
   $major_version = split($version, /\./)[0]
 
   realize Apt::Source["publiq-nodejs-${major_version}"]
-  realize Apt::Source['yarn']
+  realize Apt::Source['publiq-tools']
 
   realize Package['yarn']
 

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -69,7 +69,7 @@ class profiles::packages inherits ::profiles {
 
   @package { 'yarn':
     ensure  => 'present',
-    require => Apt::Source['yarn']
+    require => Apt::Source['publiq-tools']
   }
 
   @package { 'bundler':

--- a/spec/classes/apt/repositories_spec.rb
+++ b/spec/classes/apt/repositories_spec.rb
@@ -31,7 +31,6 @@ describe 'profiles::apt::repositories' do
         include_examples 'apt repositories', 'cultuurnet-tools'
         include_examples 'apt repositories', 'rabbitmq'
         include_examples 'apt repositories', 'elasticsearch'
-        include_examples 'apt repositories', 'yarn'
         include_examples 'apt repositories', 'erlang'
         include_examples 'apt repositories', 'publiq-jenkins'
         include_examples 'apt repositories', 'aptly'
@@ -69,12 +68,6 @@ describe 'profiles::apt::repositories' do
 
             it { is_expected.to contain_apt__source('elasticsearch').with(
               'location' => 'http://apt.uitdatabank.be/elasticsearch-testing',
-              'repos'    => 'main',
-              'release'  => 'stable'
-            ) }
-
-            it { is_expected.to contain_apt__source('yarn').with(
-              'location' => 'http://apt.uitdatabank.be/yarn-testing',
               'repos'    => 'main',
               'release'  => 'stable'
             ) }
@@ -160,12 +153,6 @@ describe 'profiles::apt::repositories' do
 
             it { is_expected.to contain_apt__source('elasticsearch').with(
               'location' => 'http://apt.uitdatabank.be/elasticsearch-acceptance',
-              'repos'    => 'main',
-              'release'  => 'stable'
-            ) }
-
-            it { is_expected.to contain_apt__source('yarn').with(
-              'location' => 'http://apt.uitdatabank.be/yarn-acceptance',
               'repos'    => 'main',
               'release'  => 'stable'
             ) }

--- a/spec/classes/deployment/uit/api_spec.rb
+++ b/spec/classes/deployment/uit/api_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'profiles::deployment::uit::api' do
   context "with config_source => /foo" do
     let(:params) { {
-      'config_source'     => '/foo'
+      'config_source' => '/foo'
     } }
 
     include_examples 'operating system support'
@@ -15,6 +15,7 @@ describe 'profiles::deployment::uit::api' do
         it { is_expected.to compile.with_all_deps }
 
         it { is_expected.to contain_apt__source('uit-api') }
+        it { is_expected.to contain_apt__source('publiq-tools') }
 
         it { is_expected.to contain_package('yarn') }
 
@@ -55,7 +56,7 @@ describe 'profiles::deployment::uit::api' do
           'cwd'         => '/var/www/uit-api',
           'user'        => 'www-data',
           'group'       => 'www-data',
-          'path'        => [ '/usr/local/bin', '/usr/bin', '/bin', '/var/www/uit-api'],
+          'path'        => ['/usr/local/bin', '/usr/bin', '/bin', '/var/www/uit-api'],
           'refreshonly' => true
         ) }
 
@@ -68,7 +69,7 @@ describe 'profiles::deployment::uit::api' do
           'cwd'         => '/var/www/uit-api',
           'user'        => 'www-data',
           'group'       => 'www-data',
-          'path'        => [ '/usr/local/bin', '/usr/bin', '/bin', '/var/www/uit-api'],
+          'path'        => ['/usr/local/bin', '/usr/bin', '/bin', '/var/www/uit-api'],
           'refreshonly' => true
         ) }
 

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -13,7 +13,7 @@ describe 'profiles::nodejs' do
         let(:params) { {} }
 
         it { is_expected.to contain_apt__source('publiq-nodejs-14') }
-        it { is_expected.to contain_apt__source('yarn') }
+        it { is_expected.to contain_apt__source('publiq-tools') }
 
         it { is_expected.to contain_class('nodejs').with(
           'manage_package_repo'   => false,
@@ -25,7 +25,7 @@ describe 'profiles::nodejs' do
         ) }
 
         it { is_expected.to contain_class('nodejs').that_requires('Apt::Source[publiq-nodejs-14]') }
-        it { is_expected.to contain_package('yarn').that_requires('Apt::Source[yarn]') }
+        it { is_expected.to contain_package('yarn').that_requires('Apt::Source[publiq-tools]') }
         it { is_expected.to contain_package('yarn').that_requires('Class[nodejs]') }
       end
 

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -102,7 +102,7 @@ describe 'profiles::packages' do
         it { is_expected.to contain_package('gcsfuse').that_requires('Apt::Source[cultuurnet-tools]') }
         it { is_expected.to contain_package('liquibase').that_requires('Apt::Source[cultuurnet-tools]') }
         it { is_expected.to contain_package('mysql-connector-java').that_requires('Apt::Source[cultuurnet-tools]') }
-        it { is_expected.to contain_package('yarn').that_requires('Apt::Source[yarn]') }
+        it { is_expected.to contain_package('yarn').that_requires('Apt::Source[publiq-tools]') }
         it { is_expected.to contain_package('policykit-1').that_requires('Apt::Source[cultuurnet-tools]') }
         it { is_expected.to contain_package('snapd').that_requires('Apt::Source[cultuurnet-tools]') }
         it { is_expected.to contain_package('libssl1.1').that_requires('Apt::Source[cultuurnet-tools]') }


### PR DESCRIPTION
### Changed

- Remove yarn apt source everywhere and replace by publiq-tools

---
Ticket: https://jira.uitdatabank.be/browse/OPS-994