### PR TITLE
Make sure to end the parameters with a newline

### DIFF
--- a/templates/jenkins/plugin/job-dsl.yaml.erb
+++ b/templates/jenkins/plugin/job-dsl.yaml.erb
@@ -6,9 +6,9 @@ jobs:
       pipelineJob('<%= pipeline['name'] %>') {
         <%- if pipeline['parameters'] -%>
           parameters {
-            <%- pipeline['parameters'].each_line do |line| -%>
+            <%- pipeline['parameters'].strip.each_line do |line| -%>
               <%= line -%>
-            <%- end -%>
+            <%- end %>
           }
         <%- end -%>
           properties {


### PR DESCRIPTION
### Changed

- Change parsing of the parameters multiline string to always end with a newline

---
Ticket: https://jira.uitdatabank.be/browse/OPS-993