### PR TITLE
Allow multiple Elasticsearch apt repositories

### DIFF
--- a/manifests/apt/repositories.pp
+++ b/manifests/apt/repositories.pp
@@ -314,6 +314,12 @@ class profiles::apt::repositories {
     repos        => 'main'
   }
 
+  @apt::source { 'elastic-5.x':
+    location => "https://apt.publiq.be/elastic-5.x-${environment}",
+    release  => $facts['os']['distro']['codename'],
+    repos    => 'main'
+  }
+
   @apt::source { 'elastic-8.x':
     location => "https://apt.publiq.be/elastic-8.x-${environment}",
     release  => $facts['os']['distro']['codename'],

--- a/manifests/elasticsearch.pp
+++ b/manifests/elasticsearch.pp
@@ -2,9 +2,11 @@ class profiles::elasticsearch (
   String $version = '5.2.2'
 ) inherits ::profiles {
 
+  $major_version = split($version, /\./)[0]
+
   contain ::profiles::java
 
-  realize Apt::Source['elasticsearch']
+  realize Apt::Source["elastic-${major_version}.x"]
 
   # TODO: parameterize this profile (version, ...)
   # TODO: add /data/backups/elasticsearch directory
@@ -28,6 +30,6 @@ class profiles::elasticsearch (
     api_timeout       => 30,
     restart_on_change => true,
     instances         => {},
-    require           => [ Apt::Source['elasticsearch'], Class['::profiles::java']]
+    require           => [ Apt::Source["elastic-${major_version}.x"], Class['::profiles::java']]
   }
 }

--- a/manifests/elasticsearch.pp
+++ b/manifests/elasticsearch.pp
@@ -1,5 +1,5 @@
 class profiles::elasticsearch (
-  String $version = 'latest'
+  String $version = '5.2.2'
 ) inherits ::profiles {
 
   contain ::profiles::java

--- a/manifests/udb3/search.pp
+++ b/manifests/udb3/search.pp
@@ -1,5 +1,5 @@
 class profiles::udb3::search (
-  String $elasticsearch_version           = 'latest',
+  String $elasticsearch_version           = '5.2.2',
   String $elasticsearch_initial_heap_size = '512m',
   String $elasticsearch_max_heap_size     = '512m'
 ) inherits ::profiles {

--- a/spec/classes/apt/repositories_spec.rb
+++ b/spec/classes/apt/repositories_spec.rb
@@ -391,6 +391,17 @@ describe 'profiles::apt::repositories' do
               'release'      => 'xenial'
             ) }
 
+            it { is_expected.to contain_apt__source('elastic-5.x').with(
+              'location'     => 'https://apt.publiq.be/elastic-5.x-acceptance',
+              'ensure'       => 'present',
+              'repos'        => 'main',
+              'include'      => {
+                'deb' => 'true',
+                'src' => 'false'
+              },
+              'release'      => 'xenial'
+            ) }
+
             it { is_expected.to contain_apt__source('elastic-8.x').with(
               'location'     => 'https://apt.publiq.be/elastic-8.x-acceptance',
               'ensure'       => 'present',

--- a/spec/classes/elasticsearch_spec.rb
+++ b/spec/classes/elasticsearch_spec.rb
@@ -18,7 +18,7 @@ describe 'profiles::elasticsearch' do
 
         it { is_expected.to contain_class('profiles::java') }
 
-        it { is_expected.to contain_apt__source('elasticsearch') }
+        it { is_expected.to contain_apt__source('elastic-5.x') }
 
         it { is_expected.to contain_file('/data/elasticsearch').with(
           'ensure' => 'directory'
@@ -36,20 +36,24 @@ describe 'profiles::elasticsearch' do
           'instances'         => {}
         ) }
 
-        it { is_expected.to contain_class('elasticsearch').that_requires('Apt::Source[elasticsearch]') }
+        it { is_expected.to contain_class('elasticsearch').that_requires('Apt::Source[elastic-5.x]') }
         it { is_expected.to contain_class('elasticsearch').that_requires('File[/data/elasticsearch]') }
         it { is_expected.to contain_class('elasticsearch').that_requires('Sysctl[vm.max_map_count]') }
         it { is_expected.to contain_class('elasticsearch').that_requires('Class[profiles::java]') }
       end
 
-      context "with version => 7.2.1" do
+      context "with version => 8.2.1" do
         let(:params) { {
-          'version' => '7.2.1'
+          'version' => '8.2.1'
         } }
 
         it { is_expected.to contain_class('elasticsearch').with(
-          'version' => '7.2.1'
+          'version' => '8.2.1'
         ) }
+
+        it { is_expected.to contain_apt__source('elastic-8.x') }
+
+        it { is_expected.to contain_class('elasticsearch').that_requires('Apt::Source[elastic-8.x]') }
       end
     end
   end

--- a/spec/classes/elasticsearch_spec.rb
+++ b/spec/classes/elasticsearch_spec.rb
@@ -12,6 +12,10 @@ describe 'profiles::elasticsearch' do
 
         it { is_expected.to compile.with_all_deps }
 
+        it { is_expected.to contain_class('profiles::elasticsearch').with(
+          'version' => '5.2.2'
+        ) }
+
         it { is_expected.to contain_class('profiles::java') }
 
         it { is_expected.to contain_apt__source('elasticsearch') }
@@ -24,12 +28,28 @@ describe 'profiles::elasticsearch' do
           'value' => '262144'
         ) }
 
-        it { is_expected.to contain_class('elasticsearch') }
+        it { is_expected.to contain_class('elasticsearch').with(
+          'version'           => '5.2.2',
+          'manage_repo'       => false,
+          'api_timeout'       => 30,
+          'restart_on_change' => true,
+          'instances'         => {}
+        ) }
 
         it { is_expected.to contain_class('elasticsearch').that_requires('Apt::Source[elasticsearch]') }
         it { is_expected.to contain_class('elasticsearch').that_requires('File[/data/elasticsearch]') }
         it { is_expected.to contain_class('elasticsearch').that_requires('Sysctl[vm.max_map_count]') }
         it { is_expected.to contain_class('elasticsearch').that_requires('Class[profiles::java]') }
+      end
+
+      context "with version => 7.2.1" do
+        let(:params) { {
+          'version' => '7.2.1'
+        } }
+
+        it { is_expected.to contain_class('elasticsearch').with(
+          'version' => '7.2.1'
+        ) }
       end
     end
   end


### PR DESCRIPTION
### Added

- Elasticsearch apt repository for ES 5.x

### Changed

- Provide the correct apt repository for specific Elasticsearch major versions