### PR TITLE
Aptly only publishes single components

### DIFF
--- a/manifests/apt/repositories.pp
+++ b/manifests/apt/repositories.pp
@@ -18,25 +18,25 @@ class profiles::apt::repositories {
       @apt::source { 'focal':
         location => "https://apt.publiq.be/focal-${environment}",
         release  => 'focal',
-        repos    => 'main universe'
+        repos    => 'main'
       }
 
       @apt::source { 'focal-updates':
         location => "https://apt.publiq.be/focal-updates-${environment}",
         release  => 'focal',
-        repos    => 'main universe'
+        repos    => 'main'
       }
 
       @apt::source { 'focal-security':
         location => "https://apt.publiq.be/focal-security-${environment}",
         release  => 'focal',
-        repos    => 'main universe'
+        repos    => 'main'
       }
 
       @apt::source { 'focal-backports':
         location => "https://apt.publiq.be/focal-backports-${environment}",
         release  => 'focal',
-        repos    => 'main universe'
+        repos    => 'main'
       }
     }
   }

--- a/spec/classes/apt/repositories_spec.rb
+++ b/spec/classes/apt/repositories_spec.rb
@@ -715,25 +715,25 @@ describe 'profiles::apt::repositories' do
 
             it { is_expected.to contain_apt__source('focal').with(
               'location' => 'https://apt.publiq.be/focal-testing',
-              'repos'    => 'main universe',
+              'repos'    => 'main',
               'release'  => 'focal'
             ) }
 
             it { is_expected.to contain_apt__source('focal-updates').with(
               'location' => 'https://apt.publiq.be/focal-updates-testing',
-              'repos'    => 'main universe',
+              'repos'    => 'main',
               'release'  => 'focal'
             ) }
 
             it { is_expected.to contain_apt__source('focal-security').with(
               'location' => 'https://apt.publiq.be/focal-security-testing',
-              'repos'    => 'main universe',
+              'repos'    => 'main',
               'release'  => 'focal'
             ) }
 
             it { is_expected.to contain_apt__source('focal-backports').with(
               'location' => 'https://apt.publiq.be/focal-backports-testing',
-              'repos'    => 'main universe',
+              'repos'    => 'main',
               'release'  => 'focal'
             ) }
           end


### PR DESCRIPTION
### Changed

- Even when we mirror multiple repo components, aptly just publishes one component (called "main")