### PR TITLE
Add LVM support to jena_fuseki profile

### DIFF
--- a/manifests/jena_fuseki.pp
+++ b/manifests/jena_fuseki.pp
@@ -1,9 +1,12 @@
 class profiles::jena_fuseki (
-  String                              $version          = 'latest',
-  Integer                             $port             = 3030,
-  String                              $jvm_args         = '-Xmx1G',
-  Integer                             $query_timeout_ms = 5000,
-  Optional[Variant[Array[Hash],Hash]] $datasets         = undef
+  String           $version          = 'latest',
+  Integer          $port             = 3030,
+  String           $jvm_args         = '-Xmx1G',
+  Integer          $query_timeout_ms = 5000,
+  Hash             $datasets         = {},
+  Boolean          $lvm              = false,
+  Optional[String] $volume_group     = undef,
+  Optional[String] $volume_size      = undef
 ) inherits ::profiles {
 
   contain ::profiles::java
@@ -20,14 +23,48 @@ class profiles::jena_fuseki (
 
   realize Apt::Source['publiq-tools']
 
+  if $lvm {
+
+    unless ($volume_group and $volume_size) {
+      fail("with LVM enabled, expects a value for both 'volume_group' and 'volume_size'")
+    }
+
+    profiles::lvm::mount { 'rdfdata':
+      volume_group => $volume_group,
+      size         => $volume_size,
+      mountpoint   => '/data/jena-fuseki/databases',
+      fs_type      => 'ext4',
+      owner        => 'fuseki',
+      group        => 'fuseki',
+      require      => [Group['fuseki'], User['fuseki']],
+      before       => Package['jena-fuseki']
+    }
+
+    file { '/var/lib/jena-fuseki':
+      ensure => 'directory',
+      owner  => 'fuseki',
+      group  => 'fuseki'
+    }
+
+    file { '/var/lib/jena-fuseki/databases':
+      ensure  => 'link',
+      target  => '/data/jena-fuseki/databases',
+      force   => true,
+      owner   => 'fuseki',
+      group   => 'fuseki',
+      require => [File['/var/lib/jena-fuseki'], Profiles::Lvm::Mount['rdfdata']],
+      before  => Package['jena-fuseki']
+    }
+  }
+
   package { 'jena-fuseki':
     ensure  => $version,
     require => [ Group['fuseki'], User['fuseki'], Apt::Source['publiq-tools'], Class['profiles::java']]
   }
 
-  if $datasets {
-    [$datasets].flatten.each |$dataset| {
-      file { "/var/lib/jena-fuseki/databases/${dataset['name']}":
+  if !$datasets.empty {
+    $datasets.each |String $name, Hash $properties| {
+      file { "/var/lib/jena-fuseki/databases/${name}":
         ensure => directory,
         owner  => 'fuseki',
         group  => 'fuseki',

--- a/manifests/lvm.pp
+++ b/manifests/lvm.pp
@@ -1,5 +1,5 @@
 class profiles::lvm (
-  Variant[Hash, Array] $volume_groups = []
+  Hash $volume_groups = {}
 ) inherits ::profiles {
 
   class { 'lvm':
@@ -14,19 +14,17 @@ class profiles::lvm (
     path   => '/data'
   }
 
-  [$volume_groups].flatten.each |Hash $volume_group| {
-    $volume_group.each |String $vg_name, Hash $vg_properties| {
-      [$vg_properties['physical_volumes']].flatten.each |String $pv| {
-        physical_volume { $pv:
-          ensure => 'present',
-          before => Volume_group[$vg_name]
-        }
+  $volume_groups.each |String $vg_name, Hash $vg_properties| {
+    [$vg_properties['physical_volumes']].flatten.each |String $pv| {
+      physical_volume { $pv:
+        ensure => 'present',
+        before => Volume_group[$vg_name]
       }
+    }
 
-      volume_group { $vg_name:
-        ensure           => 'present',
-        physical_volumes => $vg_properties['physical_volumes']
-      }
+    volume_group { $vg_name:
+      ensure           => 'present',
+      physical_volumes => $vg_properties['physical_volumes']
     }
   }
 }

--- a/spec/classes/lvm_spec.rb
+++ b/spec/classes/lvm_spec.rb
@@ -13,7 +13,7 @@ describe 'profiles::lvm' do
         it { is_expected.to compile.with_all_deps }
 
         it { is_expected.to contain_class('profiles::lvm').with(
-          'volume_groups' => []
+          'volume_groups' => {}
         ) }
 
         it { is_expected.to contain_class('lvm').with(
@@ -49,7 +49,7 @@ describe 'profiles::lvm' do
         it { is_expected.to contain_physical_volume('/dev/xvdb').that_comes_before('Volume_group[datavg]') }
       end
 
-      context "with volume_groups => [{ data1vg => { physical_volumes => '/dev/xvdb' } }, { data2vg => { physical_volumes => [ '/dev/xvdc', '/dev/xvdd'] }]" do
+      context "with volume_groups => { data1vg => { physical_volumes => '/dev/xvdb' }, data2vg => { physical_volumes => [ '/dev/xvdc', '/dev/xvdd'] }}" do
         let(:params) { {
           'volume_groups' => {
                                'data1vg' => { 'physical_volumes' => '/dev/xvdb' },

--- a/templates/jena-fuseki/config.ttl.erb
+++ b/templates/jena-fuseki/config.ttl.erb
@@ -5,22 +5,22 @@ PREFIX tdb1:    <http://jena.hpl.hp.com/2008/tdb#>
 PREFIX tdb2:    <http://jena.apache.org/2016/tdb#>
 PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
 PREFIX :        <#>
-<%- [@datasets].flatten.each do |dataset| -%>
+<%- @datasets.each do |name, properties| -%>
 
-<#<%= dataset['name'] %>_service_tdb_all> rdf:type fuseki:Service ;
-    rdfs:label      "TDB2 <%= dataset['name'] %>" ;
-    fuseki:name     "<%= "/#{dataset['endpoint'][/^\/*(.*)$/, 1]}" %>" ;
-    fuseki:dataset  <#<%= dataset['name'] %>_dataset> ;
+<#<%= name %>_service_tdb_all> rdf:type fuseki:Service ;
+    rdfs:label      "TDB2 <%= name %>" ;
+    fuseki:name     "<%= "/#{properties['endpoint'][/^\/*(.*)$/, 1]}" %>" ;
+    fuseki:dataset  <#<%= name %>_dataset> ;
 
     fuseki:endpoint [ fuseki:operation fuseki:query ] ;
     fuseki:endpoint [ fuseki:operation fuseki:update ] ;
     fuseki:endpoint [ fuseki:operation fuseki:gsp-rw ] ;
     .
 
-<#<%= dataset['name'] %>_dataset> rdf:type tdb2:DatasetTDB2 ;
-    tdb2:location "/var/lib/jena-fuseki/databases/<%= dataset['name'] %>" ;
-    <%- if dataset['union_default_graph'] -%>
-    tdb2:unionDefaultGraph <%= dataset['union_default_graph'] %> ;
+<#<%= name %>_dataset> rdf:type tdb2:DatasetTDB2 ;
+    tdb2:location "/var/lib/jena-fuseki/databases/<%= name %>" ;
+    <%- if properties['union_default_graph'] -%>
+    tdb2:unionDefaultGraph <%= properties['union_default_graph'] %> ;
     <%- end -%>
     .
 <%- end -%>


### PR DESCRIPTION
Allow specifying a volume group and a volume size for the LVM volume.
Filesystem is mounted under /data/jena-fuseki/databases and symlinked
to /var/lib/jena-fuseki/databases before package installation.