### PR TITLE
add aes256-ctr ssh cipher to allow jenkins jsch to connect

### DIFF
--- a/manifests/ssh.pp
+++ b/manifests/ssh.pp
@@ -27,7 +27,7 @@ class profiles::ssh(
 
   sshd_config { 'Ciphers':
     ensure => 'present',
-    value  => 'aes256-gcm@openssh.com'
+    value  => 'aes256-ctr,aes256-gcm@openssh.com'
   }
 
   service { 'ssh':


### PR DESCRIPTION
This enables the jenkins jsch plugin to connect over ssh to older servers.
The `aes256-ctr` cipher does not affect the Terrapin vulnerability.

```
ubuntu@bastion-prod01:~$ ~/terrapin -json -connect ip-172-30-0-194.machines.publiq.be
{
    "Banner": "SSH-2.0-OpenSSH_6.6.1p1 Ubuntu-2ubuntu2.12",
    "SupportsChaCha20": false,
    "SupportsCbcEtm": false,
    "SupportsStrictKex": false,
    "Vulnerable": false
}
```