### PR TITLE
add ubuntu to the borgbackup group on the backupserver

### DIFF
--- a/manifests/backup/server.pp
+++ b/manifests/backup/server.pp
@@ -12,6 +12,8 @@ class profiles::backup::server (
   realize User['borgbackup']
   realize Package['borgbackup']
 
+  User <| title == 'ubuntu' |> { groups +> ['borgbackup'] }
+
   @@sshkey { 'backup':
     name => $hostname,
     key  => $::sshrsakey,


### PR DESCRIPTION
This will allow the remote Synology nas to login as user ubuntu and read the borgbackup data