### PR TITLE
[CONFLUENCE] fix augeas dependency cycle

### DIFF
--- a/manifests/atlassian/confluence.pp
+++ b/manifests/atlassian/confluence.pp
@@ -103,8 +103,7 @@ class profiles::atlassian::confluence (
 
   $config.each |$key, $value| {
     confluence::conf { $key:
-      value   => $value,
-      require => Class[confluence]
+      value   => $value
     }
   }
 


### PR DESCRIPTION
the confluence::conf class in the puppet-confluence module already depends on the confluence service being present.
the require => Class[confluence] inside the confluence::conf resource in the profile should not be required