### PR TITLE
[OPS-1207] Remove google auth from jira and confluence test

### DIFF
--- a/manifests/atlassian/confluence.pp
+++ b/manifests/atlassian/confluence.pp
@@ -29,8 +29,7 @@ class profiles::atlassian::confluence (
 
   profiles::apache::vhost::reverse_proxy { "http://${servername}":
     destination         => 'http://127.0.0.1:8090/',
-    aliases             => $serveraliases,
-    auth_openid_connect => true
+    aliases             => $serveraliases
   }
 
   realize Group['confluence']

--- a/manifests/atlassian/jira.pp
+++ b/manifests/atlassian/jira.pp
@@ -30,8 +30,7 @@ class profiles::atlassian::jira (
 
   profiles::apache::vhost::reverse_proxy { "http://${servername}":
     destination         => 'http://127.0.0.1:8080/',
-    aliases             => $serveraliases,
-    auth_openid_connect => true
+    aliases             => $serveraliases
   }
 
   realize Group['jira']


### PR DESCRIPTION
Moving security to ALB via IP whitelisting.
Both service need to talk to eachother and can't get past the required google auth ...