### PR TITLE
Cleanup old atlassian backups

### DIFF
--- a/manifests/atlassian/confluence.pp
+++ b/manifests/atlassian/confluence.pp
@@ -114,6 +114,14 @@ class profiles::atlassian::confluence (
     require => [Package['mysql-connector-j'],Class['confluence']]
   }
 
+  cron { 'remove-old-confluence-backups':
+    command     => "/usr/bin/find /home/confluence/backups -mtime +1 -name '*.zip' -delete",
+    environment => [ 'MAILTO=infra+cron@publiq.be' ],
+    user        => 'root',
+    hour        => '3',
+    minute      => '40'
+  }
+
   # include ::profiles::atlassian::confluence::monitoring
   # include ::profiles::atlassian::confluence::metrics
   # include ::profiles::atlassian::confluence::backup

--- a/manifests/atlassian/jira.pp
+++ b/manifests/atlassian/jira.pp
@@ -115,6 +115,14 @@ class profiles::atlassian::jira (
     require => [Package['mysql-connector-j'],Class['jira']]
   }
 
+  cron { 'remove-old-jira-exports':
+    command     => "/usr/bin/find /home/jira/export -mtime +1 -name '*.zip' -delete",
+    environment => [ 'MAILTO=infra+cron@publiq.be' ],
+    user        => 'root',
+    hour        => '3',
+    minute      => '30'
+  }
+
   # include ::profiles::atlassian::jira::monitoring
   # include ::profiles::atlassian::jira::metrics
   # include ::profiles::atlassian::jira::backup


### PR DESCRIPTION
Both Jira and Confluence data directories are being backed up to backup-prod01. Older data can still be retrieved from there should it be necessary.