### PR TITLE
Use 'php artisan optimize' to clear caches and correct exec dependencies

### DIFF
--- a/manifests/platform/deployment.pp
+++ b/manifests/platform/deployment.pp
@@ -14,7 +14,7 @@ class profiles::platform::deployment (
                                environment => ['HOME=/'],
                                logoutput   => true,
                                refreshonly => true,
-                               subscribe   => Package['platform-api']
+                               subscribe   => [Package['platform-api'], File['platform-api-config'], File['platform-api-admin-users']]
                              }
 
   realize Apt::Source[$repository]
@@ -24,7 +24,7 @@ class profiles::platform::deployment (
   package { 'platform-api':
     ensure  => $version,
     require => Apt::Source['platform-api'],
-    notify  => [Service['platform-api'], Profiles::Deployment::Versions[$title]]
+    notify  => [Service['platform-api'], Service['platform-api-horizon'], Profiles::Deployment::Versions[$title]]
   }
 
   file { 'platform-api-config':
@@ -34,7 +34,7 @@ class profiles::platform::deployment (
     group   => 'www-data',
     source  => $config_source,
     require => [Package['platform-api'], Group['www-data'], User['www-data']],
-    notify  => [Exec['run platform cache clear'], Service['platform-api']]
+    notify  => [Service['platform-api'], Service['platform-api-horizon']]
   }
 
   file { 'platform-api-admin-users':
@@ -44,43 +44,29 @@ class profiles::platform::deployment (
     group   => 'www-data',
     source  => $admin_users_source,
     require => [Package['platform-api'], Group['www-data'], User['www-data']],
-    notify  => [Exec['run platform cache clear'], Service['platform-api']]
+    notify  => [Service['platform-api'], Service['platform-api-horizon']]
   }
 
   exec { 'run platform database migrations':
     command     => 'php artisan migrate --force',
-    require     => File['platform-api-config'],
     *           => $exec_default_attributes
   }
 
   exec { 'run platform database seed':
     command     => 'php artisan db:seed --force',
-    require     => [File['platform-api-config'], Exec['run platform database migrations']],
+    require     => Exec['run platform database migrations'],
     *           => $exec_default_attributes
   }
 
   exec { 'run platform cache clear':
     command     => 'php artisan optimize:clear',
-    require     => Exec['run platform database migrations'],
+    require     => Exec['run platform database seed'],
     *           => $exec_default_attributes
   }
 
-  exec { 'run platform route cache':
-    command     => 'php artisan route:cache',
-    require     => [File['platform-api-config'], Exec['run platform cache clear']],
-    *           => $exec_default_attributes
-  }
-
-  exec { 'run platform config cache':
-    command     => 'php artisan config:cache',
-    require     => [File['platform-api-config'], Exec['run platform route cache']],
-    *           => $exec_default_attributes
-  }
-
-  exec { 'run platform view cache':
-    command     => 'php artisan view:cache',
-    require     => [File['platform-api-config'], Exec['run platform config cache']],
-    notify      => Service['platform-api'],
+  exec { 'run platform optimize':
+    command     => 'php artisan optimize',
+    require     => Exec['run platform cache clear'],
     *           => $exec_default_attributes
   }
 


### PR DESCRIPTION
### Changed

- Use 'php artisan optimize' to clear caches instead of partial cache clear commands
- Cleanup and improve resource dependencies:
  * package update triggers all execs and service restarts
  * service restarts are done after all updates and execs
  * config file update triggers cache clear execs and service restarts