### PR TITLE
Add apache module access_compat to UiTdatabank angular app

### DIFF
--- a/manifests/uitdatabank/angular_app.pp
+++ b/manifests/uitdatabank/angular_app.pp
@@ -11,6 +11,8 @@ class profiles::uitdatabank::angular_app (
 
   include profiles::apache
 
+  apache::mod { 'access_compat': }
+
   file { $basedir:
     ensure  => 'directory',
     owner   => 'www-data',

--- a/spec/classes/uitdatabank/angular_app_spec.rb
+++ b/spec/classes/uitdatabank/angular_app_spec.rb
@@ -35,6 +35,8 @@ describe 'profiles::uitdatabank::angular_app' do
 
             it { is_expected.to contain_class('profiles::apache') }
 
+            it { is_expected.to contain_apache__mod('access_compat') }
+
             it { is_expected.to contain_profiles__apache__vhost__basic('http://app.example.com').with(
               'serveraliases' => [],
               'documentroot'  => '/var/www/udb3-angular-app',


### PR DESCRIPTION
The angular app build procedure creates a .htaccess file with the old
Apache 2.2 style access syntax (Allow, Deny, Order). This module enables
the old syntax on Apache 2.4.

---
Ticket: https://jira.uitdatabank.be/browse/III-6394