### PR TITLE
[ATLASSIAN] use environment variable to lookup vault credentials

### DIFF
--- a/manifests/atlassian/confluence.pp
+++ b/manifests/atlassian/confluence.pp
@@ -106,7 +106,7 @@ class profiles::atlassian::confluence (
 
     $database_credential = {
       "mount"    => "puppet",
-      "path"     => "testing/atlassian/confluence",
+      "path"     => "${environment}/atlassian/confluence",
       "key"      => "mysql_password",
       "endpoint" => $vault_url
     }

--- a/manifests/atlassian/jira.pp
+++ b/manifests/atlassian/jira.pp
@@ -84,7 +84,7 @@ class profiles::atlassian::jira (
 
     $vault_credential = {
       "mount"    => "puppet",
-      "path"     => "testing/atlassian/jira",
+      "path"     => "${environment}/atlassian/jira",
       "key"      => "mysql_password",
       "endpoint" => $vault_url
     }


### PR DESCRIPTION
bugfix: path to vault secret was hardcoded and incorrectly set to 'testing'