### PR TITLE
Updates for Ubuntu 24.04 compatibility

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -79,8 +79,8 @@ fixtures:
       repo: 'puppet/alternatives'
       ref: '3.0.0'
     gnupg:
-      repo: 'golja/gnupg'
-      ref: '1.2.3'
+      repo: 'h0tw1r3/gnupg'
+      ref: '1.5.2'
     java_ks:
       repo: 'puppetlabs/java_ks'
       ref: '2.2.0'

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -50,7 +50,7 @@ fixtures:
       ref: '10.1.0'
     apache:
       repo: 'puppetlabs/apache'
-      ref: '6.5.1'
+      ref: '9.1.3'
     nodejs:
       repo: 'puppet/nodejs'
       ref: '9.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 group :development, :test do
   gem 'scanf', :require => false
   gem 'json', :require => false
+  gem 'net-ftp', :require => false
   gem 'guard', :require => false
   gem 'guard-rspec', :require => false
   gem 'metadata-json-lint', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
+    date (3.4.1)
     deep_merge (1.2.2)
     diff-lcs (1.5.0)
     facter (4.3.1)
@@ -49,6 +50,11 @@ GEM
     mocha (1.16.1)
     multi_json (1.15.0)
     nenv (0.3.0)
+    net-ftp (0.3.8)
+      net-protocol
+      time
+    net-protocol (0.2.2)
+      timeout
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -108,6 +114,9 @@ GEM
     shellany (0.0.1)
     spdx-licenses (1.3.0)
     thor (1.3.0)
+    time (0.4.1)
+      date
+    timeout (0.4.3)
 
 PLATFORMS
   ruby
@@ -118,6 +127,7 @@ DEPENDENCIES
   guard-rspec
   json
   metadata-json-lint
+  net-ftp
   puppet (= 7.24.0)
   puppet-lint
   puppetlabs_spec_helper (< 3.0.0)
@@ -126,6 +136,3 @@ DEPENDENCIES
   rspec-puppet-facts
   scanf
   semantic_puppet
-
-BUNDLED WITH
-   2.2.18

--- a/manifests/apache/vhost/basic.pp
+++ b/manifests/apache/vhost/basic.pp
@@ -63,7 +63,7 @@ define profiles::apache::vhost::basic (
                                   }
   } else {
     $openid_connect_directories = []
-    $openid_connect_settings    = undef
+    $openid_connect_settings    = {}
   }
 
   apache::vhost { "${servername}_${port}":

--- a/manifests/apache/vhost/graphite_web.pp
+++ b/manifests/apache/vhost/graphite_web.pp
@@ -61,13 +61,13 @@ define profiles::apache::vhost::graphite_web (
 
     $websockets_destination = regsubst($destination,'^http(.*)/?$','ws\\1')
 
-    $rewrites = [ {
-                    'comment'      => 'Proxy Websocket support',
-                    'rewrite_cond' => [ '%{HTTP:Upgrade} =websocket [NC]'],
-                    'rewrite_rule' => "^/(.*) ${websockets_destination}\$1 [P,L]"
-                } ]
+    $rewrites = [{
+                  'comment'      => 'Proxy Websocket support',
+                  'rewrite_cond' => [ '%{HTTP:Upgrade} =websocket [NC]'],
+                  'rewrite_rule' => "^/(.*) ${websockets_destination}\$1 [P,L]"
+                }]
   } else {
-    $rewrites = undef
+    $rewrites = []
   }
 
   if $auth_openid_connect {

--- a/manifests/apache/vhost/reverse_proxy.pp
+++ b/manifests/apache/vhost/reverse_proxy.pp
@@ -92,7 +92,7 @@ define profiles::apache::vhost::reverse_proxy (
     $no_proxy_uris              = ['/redirect_uri']
   } else {
     $openid_connect_directories = []
-    $openid_connect_settings    = undef
+    $openid_connect_settings    = {}
     $no_proxy_uris              = []
   }
 

--- a/manifests/apache/vhost/reverse_proxy.pp
+++ b/manifests/apache/vhost/reverse_proxy.pp
@@ -64,13 +64,13 @@ define profiles::apache::vhost::reverse_proxy (
 
     $websockets_destination = regsubst($destination,'^http(.*)/?$','ws\\1')
 
-    $rewrites = [ {
-                    'comment'      => 'Proxy Websocket support',
-                    'rewrite_cond' => [ '%{HTTP:Upgrade} =websocket [NC]'],
-                    'rewrite_rule' => "^/(.*) ${websockets_destination}\$1 [P,L]"
-                } ]
+    $rewrites = [{
+                  'comment'      => 'Proxy Websocket support',
+                  'rewrite_cond' => [ '%{HTTP:Upgrade} =websocket [NC]'],
+                  'rewrite_rule' => "^/(.*) ${websockets_destination}\$1 [P,L]"
+                }]
   } else {
-    $rewrites = undef
+    $rewrites = []
   }
 
   if $auth_openid_connect {

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -52,10 +52,10 @@ describe 'profiles::apache' do
         it { is_expected.to contain_user('www-data').that_comes_before('Class[apache]') }
       end
 
-      context "with mpm_module => worker, mpm_module_config => { startservers => 8, maxclients => 256 }, http2 => true, limitreqfieldsize => 32766, service_status => stopped and metrics => false" do
+      context "with mpm_module => worker, mpm_module_config => { startservers => 8, maxrequestworkers => 256 }, http2 => true, limitreqfieldsize => 32766, service_status => stopped and metrics => false" do
         let(:params) { {
           'mpm_module'            => 'worker',
-          'mpm_module_config'     => { 'startservers' => 8, 'maxclients' => 256 },
+          'mpm_module_config'     => { 'startservers' => 8, 'maxrequestworkers' => 256 },
           'http2'                 => true,
           'limitreqfieldsize'     => 32766,
           'service_status'        => 'stopped',
@@ -82,8 +82,8 @@ describe 'profiles::apache' do
 
         it { is_expected.to contain_class('apache::mod::http2') }
         it { is_expected.to contain_class('apache::mod::worker').with(
-          'startservers' => 8,
-          'maxclients'   => 256
+          'startservers'      => 8,
+          'maxrequestworkers' => 256
         ) }
 
         it { is_expected.not_to contain_class('profiles::apache::metrics') }

--- a/spec/defines/apache/vhost/basic_spec.rb
+++ b/spec/defines/apache/vhost/basic_spec.rb
@@ -70,7 +70,7 @@ describe 'profiles::apache::vhost::basic' do
             'port'               => 80,
             'ssl'                => false,
             'auth_oidc'          => false,
-            'oidc_settings'      => nil,
+            'oidc_settings'      => {},
             'request_headers'    => [
                                       'unset Proxy early',
                                       'set X-Unique-Id %{UNIQUE_ID}e',

--- a/spec/defines/apache/vhost/reverse_proxy_spec.rb
+++ b/spec/defines/apache/vhost/reverse_proxy_spec.rb
@@ -61,7 +61,7 @@ describe 'profiles::apache::vhost::reverse_proxy' do
                                            ],
                 'allow_encoded_slashes' => 'off',
                 'proxy_preserve_host'   => false,
-                'rewrites'              => nil,
+                'rewrites'              => [],
                 'proxy_pass'            => {
                                              'path'          => '/',
                                              'url'           => 'http://davinci.example.com/',
@@ -120,11 +120,11 @@ describe 'profiles::apache::vhost::reverse_proxy' do
                                            ],
                 'allow_encoded_slashes' => 'off',
                 'proxy_preserve_host'   => false,
-                'rewrites'              => [ {
+                'rewrites'              => [{
                                              'comment'      => 'Proxy Websocket support',
                                              'rewrite_cond' => ['%{HTTP:Upgrade} =websocket [NC]'],
                                              'rewrite_rule' => '^/(.*) ws://davinci.example.com/$1 [P,L]'
-                                           } ],
+                                           }],
                 'proxy_pass'            => {
                                              'path'          => '/',
                                              'url'           => 'http://davinci.example.com/',
@@ -292,7 +292,7 @@ describe 'profiles::apache::vhost::reverse_proxy' do
                                            ],
                 'allow_encoded_slashes' => 'off',
                 'proxy_preserve_host'   => false,
-                'rewrites'              => nil,
+                'rewrites'              => [],
                 'proxy_pass'            => {
                                              'path'          => '/',
                                              'url'           => 'https://buonarotti.example.com/',

--- a/spec/defines/apache/vhost/reverse_proxy_spec.rb
+++ b/spec/defines/apache/vhost/reverse_proxy_spec.rb
@@ -53,7 +53,7 @@ describe 'profiles::apache::vhost::reverse_proxy' do
                                            ],
                 'access_log_format'     => 'extended_json',
                 'auth_oidc'             => false,
-                'oidc_settings'         => nil,
+                'oidc_settings'         => {},
                 'directories'           => [],
                 'setenvif'              => [
                                              'X-Forwarded-Proto "https" HTTPS=on',
@@ -202,12 +202,12 @@ describe 'profiles::apache::vhost::reverse_proxy' do
                 'allow_encoded_slashes' => 'nodecode',
                 'auth_oidc'             => false,
                 'directories'           => [],
-                'oidc_settings'         => nil,
-                'rewrites'              => [ {
+                'oidc_settings'         => {},
+                'rewrites'              => [{
                                              'comment'      => 'Proxy Websocket support',
                                              'rewrite_cond' => ['%{HTTP:Upgrade} =websocket [NC]'],
                                              'rewrite_rule' => '^/(.*) wss://buonarotti.example.com/$1 [P,L]'
-                                           } ],
+                                           }],
                 'proxy_pass'            => {
                                              'path'          => '/',
                                              'url'           => 'https://buonarotti.example.com/',


### PR DESCRIPTION
- **Explicitly add net-ftp (apt module needs it), as it is not bundled with ruby since 3.1.0**
- **Use maintained fork of gnupg module that gets rid of deprecated URI.escape method**
- **Update apache module to fix broken vhost/_require template on Ubuntu 24.04**
