### PR TITLE
Don't provide a default value for vault lookups

### DIFF
--- a/manifests/uitdatabank/websocket_server/deployment.pp
+++ b/manifests/uitdatabank/websocket_server/deployment.pp
@@ -9,7 +9,7 @@ class profiles::uitdatabank::websocket_server::deployment (
 ) inherits ::profiles {
 
   $basedir = '/var/www/udb3-websocket-server'
-  $secrets = lookup('vault:uitdatabank/udb3-websocket-server', undef, undef, {})
+  $secrets = lookup('vault:uitdatabank/udb3-websocket-server')
 
   realize Apt::Source[$repository]
   realize Group['www-data']


### PR DESCRIPTION
- **Always include vault data when using hieradata**
- **Add vault hieradata for UiTdatabank websocket server**
- **Lookup vault data in deployment profile and provide an existing template for the configuration**
- **Provide a default secret value as there are no secrets for UiTdatabank websocket server**
- **Don't provide a default value for vault lookups**
