### PR TITLE
Export Jira Vault token

### DIFF
--- a/manifests/atlassian/jira.pp
+++ b/manifests/atlassian/jira.pp
@@ -77,6 +77,10 @@ class profiles::atlassian::jira (
     $vault_token = lookup('vault:atlassian/vault_token')
     $vault_url   = lookup('data::vault::url')
 
+    @@profiles::vault::renew_token { "profiles::atlassian::jira ${environment}":
+      token_value => $vault_token['token']
+    }
+
     systemd::dropin_file { 'jira-override.conf':
       unit    => 'jira.service',
       content => "[Service]\nEnvironment=\"SECRET_STORE_VAULT_TOKEN=${vault_token['token']}\""


### PR DESCRIPTION
This token is used by Jira to access the vault to retrieve the mysql password.
This token expires after 8 days and must be refreshed.
This code creates an exported resource which is picked up by the vault server where it is used inside a refresher cronjob