### PR TITLE
Adds ECS Agent profile

### DIFF
--- a/manifests/ecsagent.pp
+++ b/manifests/ecsagent.pp
@@ -1,0 +1,37 @@
+class profiles::ecsagent (
+
+  String $ecs_cluster_name   = undef,
+) inherits ::profiles {
+  
+  realize Apt::Source['publiq-tools']
+
+  package { 'amazon-ecs-init':
+    ensure  => 'present',
+    require => Apt::Source['publiq-tools']
+  }
+
+  realize Package['amazon-ecs-init']
+  file { '/etc/ecs':
+    ensure => 'directory',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+    require => Package['amazon-ecs-init']
+  }
+  if $ecs_cluster_name {
+    file { '/etc/ecs/ecs.config':
+      ensure  => 'file',
+      content => "ECS_CLUSTER=${ecs_cluster_name}",
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      require => Package['amazon-ecs-init']
+    }
+  }
+  service { 'ecs':
+    ensure    => 'running',
+    enable    => true,
+    require   => Package['amazon-ecs-init'],
+    subscribe => File['/etc/ecs/ecs.config']
+  }
+}


### PR DESCRIPTION
Adds a class to manage the installation and configuration of the ECS Agent.

This allows for the agent to be installed, started and configured via puppet and hieradata. It configures the ECS cluster name if one is specified.

Ticket: https://jira.uitdatabank.be/browse/...
