### PR TITLE
Use Vault for Google Cloud credentials in elasticdump_to_gcs profile

### DIFF
--- a/manifests/google/gcloud/credentials.pp
+++ b/manifests/google/gcloud/credentials.pp
@@ -1,0 +1,19 @@
+define profiles::google::gcloud::credentials (
+  String $project_id,
+  String $private_key_id,
+  String $private_key,
+  String $client_id,
+  String $client_email
+) {
+
+  include ::profiles
+
+  realize File['/etc/gcloud']
+
+  file { "gcloud credentials ${title}":
+    ensure  => 'file',
+    path    => "/etc/gcloud/credentials_${title}.json",
+    content => template('profiles/google/gcloud/credentials.json.erb'),
+    require => File['/etc/gcloud']
+  }
+}

--- a/manifests/uitdatabank/search_api/elasticdump_to_gcs.pp
+++ b/manifests/uitdatabank/search_api/elasticdump_to_gcs.pp
@@ -2,15 +2,23 @@ class profiles::uitdatabank::search_api::elasticdump_to_gcs (
   Optional[String] $project_id          = undef,
   Optional[String] $bucket_name         = undef,
   String           $bucket_dumplocation = '',
-  Optional[String] $credentials_source  = undef,
   Boolean          $dump_schedule       = false,
   Integer          $dump_hour           = 0,
   String           $local_timezone      = 'UTC'
 ) inherits ::profiles {
 
-  profiles::google::gcloud { 'root':
-    credentials_source => $credentials_source,
-    project            => $project_id
+  if $project_id {
+    $secrets = lookup('vault:uitdatabank/udb3-search-service')
+
+    profiles::google::gcloud { 'root':
+      credentials => {
+                       project_id     => $project_id,
+                       private_key_id => $secrets['gcloud_private_key_id'],
+                       private_key    => $secrets['gcloud_private_key'],
+                       client_id      => $secrets['gcloud_client_id'],
+                       client_email   => $secrets['gcloud_client_email']
+                     }
+    }
   }
 
   if $bucket_name {

--- a/spec/classes/uitdatabank/search_api/elasticdump_to_gcs_spec.rb
+++ b/spec/classes/uitdatabank/search_api/elasticdump_to_gcs_spec.rb
@@ -11,76 +11,92 @@ describe 'profiles::uitdatabank::search_api::elasticdump_to_gcs' do
           'bucket_name' => 'foo'
         } }
 
-        it { is_expected.to compile.with_all_deps }
+        context "with hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
 
-        it { is_expected.to contain_class('profiles::uitdatabank::search_api::elasticdump_to_gcs').with(
-          'project_id'             => 'bla',
-          'bucket_name'            => 'foo',
-          'bucket_dumplocation'    => '',
-          'credentials_source'     => nil,
-          'dump_schedule'          => false,
-          'dump_hour'              => 0,
-          'local_timezone'         => 'UTC'
-        ) }
+          it { is_expected.to compile.with_all_deps }
 
-        it { is_expected.to contain_profiles__google__gcloud('root').with(
-          'project_id'         => 'bla',
-          'credentials_source' => nil
-        ) }
+          it { is_expected.to contain_class('profiles::uitdatabank::search_api::elasticdump_to_gcs').with(
+            'project_id'             => 'bla',
+            'bucket_name'            => 'foo',
+            'bucket_dumplocation'    => '',
+            'dump_schedule'          => false,
+            'dump_hour'              => 0,
+            'local_timezone'         => 'UTC'
+          ) }
 
-        it { is_expected.to contain_file('elasticdump_to_gcs').with(
-          'ensure' => 'file',
-          'path'   => '/usr/local/bin/elasticdump_to_gcs',
-          'mode'   => '0755'
-        ) }
+          it { is_expected.to contain_profiles__google__gcloud('root').with(
+            'credentials' => {
+                               'project_id'     => 'bla',
+                               'private_key_id' => 'foo',
+                               'private_key'    => 'my\nprivate\nkey',
+                               'client_id'      => 'bar',
+                               'client_email'   => 'bar@example.com'
+                             }
+          ) }
 
-        it { is_expected.to contain_file('elasticdump_to_gcs').with_content(/^bucket_name=foo$/) }
-        it { is_expected.to contain_file('elasticdump_to_gcs').with_content(/^bucket_dumplocation=$/) }
+          it { is_expected.to contain_file('elasticdump_to_gcs').with(
+            'ensure' => 'file',
+            'path'   => '/usr/local/bin/elasticdump_to_gcs',
+            'mode'   => '0755'
+          ) }
 
-        it { is_expected.to contain_cron('elasticdump_to_gcs').with(
-          'ensure'      => 'absent',
-          'command'     => '/usr/bin/test $(date +\\%0H) -eq 0 && /usr/local/bin/elasticdump_to_gcs /data/backup/elasticsearch/current/udb3_core_v*',
-          'environment' => ['SHELL=/bin/bash', 'TZ=UTC', 'MAILTO=infra+cron@publiq.be'],
-          'hour'        => '*',
-          'minute'      => '00'
-        ) }
+          it { is_expected.to contain_file('elasticdump_to_gcs').with_content(/^bucket_name=foo$/) }
+          it { is_expected.to contain_file('elasticdump_to_gcs').with_content(/^bucket_dumplocation=$/) }
 
-        it { is_expected.to contain_file('elasticdump_to_gcs').that_requires('Profiles::Google::Gcloud[root]') }
-        it { is_expected.to contain_cron('elasticdump_to_gcs').that_requires('File[elasticdump_to_gcs]') }
+          it { is_expected.to contain_cron('elasticdump_to_gcs').with(
+            'ensure'      => 'absent',
+            'command'     => '/usr/bin/test $(date +\\%0H) -eq 0 && /usr/local/bin/elasticdump_to_gcs /data/backup/elasticsearch/current/udb3_core_v*',
+            'environment' => ['SHELL=/bin/bash', 'TZ=UTC', 'MAILTO=infra+cron@publiq.be'],
+            'hour'        => '*',
+            'minute'      => '00'
+          ) }
+
+          it { is_expected.to contain_file('elasticdump_to_gcs').that_requires('Profiles::Google::Gcloud[root]') }
+          it { is_expected.to contain_cron('elasticdump_to_gcs').that_requires('File[elasticdump_to_gcs]') }
+        end
       end
 
-      context "with project_id => foobar, bucket_name => bar, credentials_source => /tmp/secret, dump_schedule => true, bucket_dumplocation => dir1/dir2, dump_hour => 12 and local_timezone => Europe/Paris" do
+      context "with project_id => foobar, bucket_name => bar, dump_schedule => true, bucket_dumplocation => dir1/dir2, dump_hour => 12 and local_timezone => Europe/Paris" do
         let(:params) { {
           'project_id'          => 'foobar',
           'bucket_name'         => 'bar',
-          'credentials_source'  => '/tmp/secret',
           'dump_schedule'       => true,
           'bucket_dumplocation' => 'dir1/dir2',
           'dump_hour'           => 12,
           'local_timezone'      => 'Europe/Paris'
         } }
 
-        it { is_expected.to contain_profiles__google__gcloud('root').with(
-          'project_id'         => 'foobar',
-          'credentials_source' => '/tmp/secret'
-        ) }
+        context "with hieradata" do
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
 
-        it { is_expected.to contain_file('elasticdump_to_gcs').with(
-          'ensure' => 'file',
-          'path'   => '/usr/local/bin/elasticdump_to_gcs',
-          'mode'   => '0755'
-        ) }
+          it { is_expected.to contain_profiles__google__gcloud('root').with(
+            'credentials' => {
+                               'project_id'     => 'foobar',
+                               'private_key_id' => 'foo',
+                               'private_key'    => 'my\nprivate\nkey',
+                               'client_id'      => 'bar',
+                               'client_email'   => 'bar@example.com'
+                             }
+          ) }
 
-        it { is_expected.to contain_file('elasticdump_to_gcs').with_content(/^bucket_name=bar$/) }
-        it { is_expected.to contain_file('elasticdump_to_gcs').with_content(/^bucket_dumplocation=dir1\/dir2$/) }
+          it { is_expected.to contain_file('elasticdump_to_gcs').with(
+            'ensure' => 'file',
+            'path'   => '/usr/local/bin/elasticdump_to_gcs',
+            'mode'   => '0755'
+          ) }
 
-        it { is_expected.to contain_cron('elasticdump_to_gcs').with(
-          'ensure'      => 'present',
-          'command'     => '/usr/bin/test $(date +\\%0H) -eq 12 && /usr/local/bin/elasticdump_to_gcs /data/backup/elasticsearch/current/udb3_core_v*',
-          'environment' => ['SHELL=/bin/bash', 'TZ=Europe/Paris', 'MAILTO=infra+cron@publiq.be'],
-          'hour'        => '*',
-          'minute'      => '00'
-        ) }
+          it { is_expected.to contain_file('elasticdump_to_gcs').with_content(/^bucket_name=bar$/) }
+          it { is_expected.to contain_file('elasticdump_to_gcs').with_content(/^bucket_dumplocation=dir1\/dir2$/) }
+
+          it { is_expected.to contain_cron('elasticdump_to_gcs').with(
+            'ensure'      => 'present',
+            'command'     => '/usr/bin/test $(date +\\%0H) -eq 12 && /usr/local/bin/elasticdump_to_gcs /data/backup/elasticsearch/current/udb3_core_v*',
+            'environment' => ['SHELL=/bin/bash', 'TZ=Europe/Paris', 'MAILTO=infra+cron@publiq.be'],
+            'hour'        => '*',
+            'minute'      => '00'
+          ) }
+        end
       end
 
       context "without parameters" do
@@ -90,17 +106,14 @@ describe 'profiles::uitdatabank::search_api::elasticdump_to_gcs' do
           'project_id'          => nil,
           'bucket_name'         => nil,
           'bucket_dumplocation' => '',
-          'credentials_source'  => nil,
           'dump_schedule'       => false,
           'dump_hour'           => 0,
           'local_timezone'      => 'UTC'
         ) }
 
-        it { is_expected.to contain_profiles__google__gcloud('root').with(
-          'project_id'         => nil,
-          'credentials_source' => nil
-        ) }
+        it { is_expected.to compile.with_all_deps }
 
+        it { is_expected.not_to contain_profiles__google__gcloud('root') }
         it { is_expected.not_to contain_file('elasticdump_to_gcs') }
         it { is_expected.not_to contain_cron('elasticdump_to_gcs') }
       end

--- a/spec/defines/google/gcloud/credentials_spec.rb
+++ b/spec/defines/google/gcloud/credentials_spec.rb
@@ -1,0 +1,75 @@
+describe 'profiles::google::gcloud::credentials' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      context "with title root" do
+        let(:title) { 'root' }
+
+        context 'with project_id => foo, private_key_id => 123abc, private_key => xyz789, client_id => 456def and client_email => foo@example.com' do
+          let(:params) { {
+            'project_id'     => 'foo',
+            'private_key_id' => '123abc',
+            'private_key'    => 'xyz789',
+            'client_id'      => '456def',
+            'client_email'   => 'foo@example.com'
+          } }
+
+          it { is_expected.to compile.with_all_deps }
+
+          it { is_expected.to contain_file('/etc/gcloud') }
+
+          it { is_expected.to contain_file('gcloud credentials root').with(
+            'ensure' => 'file',
+            'path'   => '/etc/gcloud/credentials_root.json'
+          ) }
+
+          it { is_expected.to contain_file('gcloud credentials root').with_content(/\s*"project_id": "foo",?$/) }
+          it { is_expected.to contain_file('gcloud credentials root').with_content(/\s*"private_key_id": "123abc",?$/) }
+          it { is_expected.to contain_file('gcloud credentials root').with_content(/\s*"private_key": "xyz789",?$/) }
+          it { is_expected.to contain_file('gcloud credentials root').with_content(/\s*"client_id": "456def",?$/) }
+          it { is_expected.to contain_file('gcloud credentials root').with_content(/\s*"client_email": "foo@example.com",?$/) }
+          it { is_expected.to contain_file('gcloud credentials root').with_content(/\s*"client_x509_cert_url": "https:\/\/www.googleapis.com\/robot\/v1\/metadata\/x509\/foo%40example.com",?$/) }
+        end
+
+        context "without parameters" do
+          let(:params) { {} }
+
+          it { expect { catalogue }.to raise_error(Puppet::ParseError, /expects a value for parameter 'project_id'/) }
+          it { expect { catalogue }.to raise_error(Puppet::ParseError, /expects a value for parameter 'private_key_id'/) }
+          it { expect { catalogue }.to raise_error(Puppet::ParseError, /expects a value for parameter 'private_key'/) }
+          it { expect { catalogue }.to raise_error(Puppet::ParseError, /expects a value for parameter 'client_id'/) }
+          it { expect { catalogue }.to raise_error(Puppet::ParseError, /expects a value for parameter 'client_email'/) }
+        end
+      end
+
+      context "with title jenkins" do
+        let(:title) { 'jenkins' }
+
+        context "with project_id => bar, private_key_id => qwertyuiop, private_key => poiuytrewq, client_id => baz and client_email => baz@example.com" do
+          let(:params) { {
+            'project_id'     => 'bar',
+            'private_key_id' => 'qwertyuiop',
+            'private_key'    => 'poiuytrewq',
+            'client_id'      => 'baz',
+            'client_email'   => 'baz@example.com'
+          } }
+
+          it { is_expected.to compile.with_all_deps }
+
+          it { is_expected.to contain_file('gcloud credentials jenkins').with(
+            'ensure' => 'file',
+            'path'   => '/etc/gcloud/credentials_jenkins.json'
+          ) }
+
+          it { is_expected.to contain_file('gcloud credentials jenkins').with_content(/\s*"project_id": "bar",?$/) }
+          it { is_expected.to contain_file('gcloud credentials jenkins').with_content(/\s*"private_key_id": "qwertyuiop",?$/) }
+          it { is_expected.to contain_file('gcloud credentials jenkins').with_content(/\s*"private_key": "poiuytrewq",?$/) }
+          it { is_expected.to contain_file('gcloud credentials jenkins').with_content(/\s*"client_id": "baz",?$/) }
+          it { is_expected.to contain_file('gcloud credentials jenkins').with_content(/\s*"client_email": "baz@example.com",?$/) }
+          it { is_expected.to contain_file('gcloud credentials jenkins').with_content(/\s*"client_x509_cert_url": "https:\/\/www.googleapis.com\/robot\/v1\/metadata\/x509\/baz%40example.com",?$/) }
+        end
+      end
+    end
+  end
+end

--- a/spec/support/hiera/data/vault.yaml
+++ b/spec/support/hiera/data/vault.yaml
@@ -8,4 +8,8 @@ vault:uitdatabank/udb3-jwtprovider: {}
 vault:uitdatabank/uit-articlelinker: {}
 vault:uitdatabank/udb3-angular-app: {}
 vault:uitdatabank/udb3-frontend: {}
-vault:uitdatabank/udb3-search-service: {}
+vault:uitdatabank/udb3-search-service:
+  gcloud_private_key_id: 'foo'
+  gcloud_private_key: 'my\nprivate\nkey'
+  gcloud_client_id: 'bar'
+  gcloud_client_email: 'bar@example.com'

--- a/templates/google/gcloud/credentials.json.erb
+++ b/templates/google/gcloud/credentials.json.erb
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "<%= @project_id %>",
+  "private_key_id": "<%= @private_key_id %>",
+  "private_key": "<%= @private_key %>",
+  "client_email": "<%= @client_email %>",
+  "client_id": "<%= @client_id %>",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/<%= ERB::Util.url_encode(@client_email) %>"
+}


### PR DESCRIPTION
- **Add profile for managing Google Cloud service account credentials**
- **Use separate credentials profile in Google Cloud profile**
- **Add template for Google Cloud service account credentials**
- **Use Vault for Google Cloud credentials**
