### PR TITLE
Allows configuring log rotation period

### DIFF
--- a/manifests/apache/logging.pp
+++ b/manifests/apache/logging.pp
@@ -1,10 +1,12 @@
-class profiles::apache::logging inherits ::profiles {
+class profiles::apache::logging (
+  Integer $keep_logs_days     = 21
+) inherits ::profiles {
 
   include profiles::logrotate
 
   logrotate::rule { 'apache2':
     path         => '/var/log/apache2/*.log',
-    rotate       => 21,
+    rotate       => $keep_logs_days,
     create_owner => 'root',
     create_group => 'adm',
     postrotate   => 'systemctl status apache2 > /dev/null 2>&1 && systemctl reload apache2 > /dev/null 2>&1',

--- a/spec/classes/apache/logging_spec.rb
+++ b/spec/classes/apache/logging_spec.rb
@@ -5,23 +5,49 @@ describe 'profiles::apache::logging' do
     context "on #{os}" do
       let(:facts) { facts }
 
-      it { is_expected.to compile.with_all_deps }
+      context 'without parameters' do
+        let(:params) { {} }
+        it { is_expected.to compile.with_all_deps }
 
-      it { is_expected.to contain_class('profiles::logrotate') }
+        it { is_expected.to contain_class('profiles::logrotate') }
+        it { is_expected.to contain_class('profiles::apache::logging').with( 
 
-      it { is_expected.to contain_logrotate__rule('apache2').with(
-        'path'          => '/var/log/apache2/*.log',
-        'rotate'        => 21,
-        'rotate_every'  => 'day',
-        'create'        => true,
-        'create_mode'   => '0640',
-        'create_owner'  => 'root',
-        'create_group'  => 'adm',
-        'compress'      => true,
-        'delaycompress' => true,
-        'sharedscripts' => true,
-        'postrotate'    => 'systemctl status apache2 > /dev/null 2>&1 && systemctl reload apache2 > /dev/null 2>&1'
-      ) }
+          'keep_logs_days' => 21,
+        ) }
+
+        it { is_expected.to contain_logrotate__rule('apache2').with(
+          'path'          => '/var/log/apache2/*.log',
+          'rotate'        => 21,
+          'rotate_every'  => 'day',
+          'create'        => true,
+          'create_mode'   => '0640',
+          'create_owner'  => 'root',
+          'create_group'  => 'adm',
+          'compress'      => true,
+          'delaycompress' => true,
+          'sharedscripts' => true,
+          'postrotate'    => 'systemctl status apache2 > /dev/null 2>&1 && systemctl reload apache2 > /dev/null 2>&1'
+        ) }
+      end
+      context 'with keep_logs_days => 30' do
+        let(:params) { {
+          'keep_logs_days' => 30
+        } }
+
+        it { is_expected.to contain_logrotate__rule('apache2').with(
+          'path'          => '/var/log/apache2/*.log',
+          'rotate'        => 30,
+          'rotate_every'  => 'day',
+          'create'        => true,
+          'create_mode'   => '0640',
+          'create_owner'  => 'root',
+          'create_group'  => 'adm',
+          'compress'      => true,
+          'delaycompress' => true,
+          'sharedscripts' => true,
+          'postrotate'    => 'systemctl status apache2 > /dev/null 2>&1 && systemctl reload apache2 > /dev/null 2>&1'
+        ) }
+      end
     end
   end
 end


### PR DESCRIPTION

### Added

- Introduces a parameter to control how long logs are kept. This allows us to customize the log rotation policy based on their specific needs and storage capacity.

### Changed

-

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
