### PR TITLE
Enables empty dumps for Sling

### DIFF
--- a/manifests/sling.pp
+++ b/manifests/sling.pp
@@ -3,6 +3,7 @@ class profiles::sling (
   Optional[String] $database_name  = undef,
   Optional[String] $project_id     = undef,
   Optional[String] $bucket_name    = undef,
+  Boolean $dump_empty_tables       = true,
   Integer $cron_hour               = 2,
   String           $local_timezone = 'UTC'
 

--- a/templates/sling/sling.env.erb
+++ b/templates/sling/sling.env.erb
@@ -1,4 +1,4 @@
 connections:
   MYSQL_URL:
     url: "mysql://sling:<%= @app_user_password %>@127.0.0.1:3306/<%= @database_name %>?tls=skip-verify&allowFallbackToPlaintext=true"
-SLING_ALLOW_EMPTY: true
+SLING_ALLOW_EMPTY: <%= @dump_empty_tables %>

--- a/templates/sling/sling.env.erb
+++ b/templates/sling/sling.env.erb
@@ -1,3 +1,4 @@
 connections:
   MYSQL_URL:
     url: "mysql://sling:<%= @app_user_password %>@127.0.0.1:3306/<%= @database_name %>?tls=skip-verify&allowFallbackToPlaintext=true"
+SLING_ALLOW_EMPTY: true


### PR DESCRIPTION
Allow creation of parquet files without data if table is empty

### Added

-

### Changed

- Enables empty parquet dumps for Sling 

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
