### PR TITLE
Update preserve host

### DIFF
--- a/manifests/uitpas/segmentatie.pp
+++ b/manifests/uitpas/segmentatie.pp
@@ -121,21 +121,6 @@ class profiles::uitpas::segmentatie (
     *       => $default_attributes,
   }
 
-  set { 'server.network-config.protocols.protocol.http-listener-1.http.server-name-header':
-    ensure  => 'present',
-    value   => 'X-Forwarded-Host',
-    require => Profiles::Glassfish::Domain['uitpas-segmentatie'],
-    notify  => Service['uitpas-segmentatie'],
-    *       => $default_attributes,
-  }
-
-  set { 'server.network-config.protocols.protocol.http-listener-1.http.server-port-header':
-    ensure  => 'present',
-    value   => 'X-Forwarded-Port',
-    require => Profiles::Glassfish::Domain['uitpas-segmentatie'],
-    notify  => Service['uitpas-segmentatie'],
-    *       => $default_attributes,
-  }
 
   set { 'server.thread-pools.thread-pool.http-thread-pool.max-thread-pool-size':
     ensure  => 'present',


### PR DESCRIPTION
This pull request makes a change to the `manifests/uitpas/segmentatie.pp` file. The change enhances the reverse proxy configuration

Enhancements to reverse proxy configuration:

* [`manifests/uitpas/segmentatie.pp`](diffhunk://#diff-d85c5a1bd0fa85517ab41de8091591c2ef228fa5099d75a87b8b9ffd144f2b14R34): Added the `preserve_host => true` parameter to the reverse proxy configuration to ensure the original host header is preserved when forwarding requests.
