### PR TITLE
Set env vars to allow empty tables for Sling exports

### DIFF
--- a/templates/sling/parquetdump_to_gcs.sh.erb
+++ b/templates/sling/parquetdump_to_gcs.sh.erb
@@ -1,5 +1,9 @@
 #!/bin/bash
 # This script dumps all tables from the 'platform' database into Parquet files.
+
+export SLING_ALLOW_EMPTY=<%= @dump_empty_tables %>
+export SLING_ALLOW_EMPTY_TABLES=<%= @dump_empty_tables %>
+
 for dbasetable in $(mysql -h 127.0.0.1 -u sling -p<%= @app_user_password %> <%= @database_name %> --batch --skip-column-names -e 'show tables;')
 do
   echo "Dumping table $dbasetable from database <%= @database_name %> to Parquet file"

--- a/templates/sling/sling.env.erb
+++ b/templates/sling/sling.env.erb
@@ -1,4 +1,3 @@
 connections:
   MYSQL_URL:
     url: "mysql://sling:<%= @app_user_password %>@127.0.0.1:3306/<%= @database_name %>?tls=skip-verify&allowFallbackToPlaintext=true"
-SLING_ALLOW_EMPTY: <%= @dump_empty_tables %>


### PR DESCRIPTION
This pull request updates the configuration and environment setup for the Sling application to handle empty table dumps more consistently. The most important changes include adding new environment variables in the Parquet dump script and removing redundant configuration from the Sling environment file.

### Configuration updates for handling empty table dumps:

* [`templates/sling/parquetdump_to_gcs.sh.erb`](diffhunk://#diff-3ba9f76030429a54b3c7197f22e91a763db10c3c441c912ac24897dcb88ca750R3-R6): Added two new environment variables, `SLING_ALLOW_EMPTY` and `SLING_ALLOW_EMPTY_TABLES`, to control whether empty tables should be dumped. These variables are dynamically set based on the `@dump_empty_tables` parameter.

* [`templates/sling/sling.env.erb`](diffhunk://#diff-e678a8fea917bbadca1a7ddd2a810a51b469d3c96b6dc2475da9f2d9410395baL4): Removed the `SLING_ALLOW_EMPTY` configuration from the environment file, as it is now set directly in the Parquet dump script.