### PR TITLE
Add cronjob to sync DB for segmentatie

### DIFF
--- a/manifests/uitpas/segmentatie.pp
+++ b/manifests/uitpas/segmentatie.pp
@@ -10,6 +10,7 @@ class profiles::uitpas::segmentatie (
   Optional[String] $initial_heap_size          = undef,
   Optional[String] $maximum_heap_size          = undef,
   Boolean $jmx                                 = true,
+  Boolean $cron_enabled                        = true,
   Integer $portbase                            = 4800,
   Enum['running', 'stopped'] $service_status   = 'running',
   Hash $settings                               = {}
@@ -103,7 +104,8 @@ class profiles::uitpas::segmentatie (
     if $deployment {
       class { 'profiles::uitpas::segmentatie::deployment':
         portbase          => $portbase,
-        config_source => $config_source
+        config_source => $config_source,
+        cron_enabled    => $cron_enabled,
       }
 
       Class['profiles::glassfish'] -> Class['profiles::uitpas::segmentatie::deployment']

--- a/manifests/uitpas/segmentatie/deployment.pp
+++ b/manifests/uitpas/segmentatie/deployment.pp
@@ -4,6 +4,7 @@ class profiles::uitpas::segmentatie::deployment (
   String           $repository        = 'uitpas-segmentatie',
   String           $config_source ,
   Integer          $portbase          = 4800,
+  Integer          $cron_enabled      = true,
 ) inherits profiles {
   $secrets = lookup('vault:uitpas/segmentatie')
 
@@ -18,6 +19,17 @@ class profiles::uitpas::segmentatie::deployment (
     require => Apt::Source[$repository],
     notify  => [App['uitpas-segmentatie']],
   }
+  if $cron_enabled {
+  cron { 'uitpas-segmentatie-sync':
+      ensure  => 'present',
+      command => "/usr/bin/curl -X POST 'http://localhost:4880/segmentation/rest/sync",
+      user    => 'www-data',
+      hour    => 1,
+      minute  => 45,
+      require => Package['uitpas-segmentatie'],
+    }
+  }
+
   file { '/opt/uitpas-segmentatie/.env':
     ensure  => 'file',
     owner   => 'glassfish',


### PR DESCRIPTION
This pull request introduces a new feature to enable or disable a cron job for the `uitpas-segmentatie` service through a configurable parameter. The changes primarily involve adding a `cron_enabled` parameter and implementing logic to conditionally manage the cron job.

### New Feature: Configurable Cron Job

* **Added `cron_enabled` parameter**:
  - Introduced a new `Boolean` parameter `cron_enabled` in `manifests/uitpas/segmentatie.pp` to allow enabling or disabling the cron job for the service. Default is set to `true`.
  - Passed the `cron_enabled` parameter to the `profiles::uitpas::segmentatie::deployment` class.
  - Added the `cron_enabled` parameter to the `manifests/uitpas/segmentatie/deployment.pp` class definition.

* **Conditional cron job management**:
  - Added logic in `manifests/uitpas/segmentatie/deployment.pp` to create a cron job (`uitpas-segmentatie-sync`) only when `cron_enabled` is set to `true`. The cron job executes a sync operation via a `curl` command daily at 1:45 AM.