### PR TITLE
Make UiTdatabank RDF vhost serve the GET requests to specific endpoints

### DIFF
--- a/manifests/uitdatabank/rdf.pp
+++ b/manifests/uitdatabank/rdf.pp
@@ -1,60 +1,52 @@
 class profiles::uitdatabank::rdf (
-  String          $servername,
-  Stdlib::HTTPUrl $backend_url
+  String                         $servername,
+  Variant[String, Array[String]] $serveraliases = [],
+  Boolean                        $deployment    = true
 ) inherits ::profiles {
 
-  include ::profiles::firewall::rules
+  $basedir = '/var/www/udb3-backend'
+
   include ::profiles::apache
+  include ::profiles::redis
+  include ::profiles::php
 
-  $port                  = 80
-  $transport             = 'http'
-  $backend_url_sanitized = regsubst($backend_url, '/$', '')
-  $rewrites              = [ {
-                             comment      => 'Reverse proxy /(events|places|organizers)/<uuid> to backend',
-                             rewrite_cond => [
-                                               '%{REQUEST_URI} "^/(events|places|organizers)/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$" [OR]',
-                                               '%{REQUEST_URI} "^/(events|places|organizers)/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{16}$"'
-                                             ],
-                             rewrite_rule => "^/(events|places|organizers)/(.*)\$ ${backend_url_sanitized}/\$1/\$2 [P]"
-                           }, {
-                             comment      => 'Reverse proxy /id/(event|place|organizer)/udb/<uuid> to backend',
-                             rewrite_cond => [
-                                               '%{REQUEST_URI} "^/id/(event|place|organizer)/udb/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$" [OR]',
-                                               '%{REQUEST_URI} "^/id/(event|place|organizer)/udb/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{16}$"'
-                                             ],
-                             rewrite_rule => "^/id/(event|place|organizer)/udb/(.*)\$ ${backend_url_sanitized}/\$1s/\$2 [P]"
-                           } ]
+  $rewrites = [{
+                comment      => 'Only allow GET requests',
+                rewrite_cond => ['%{REQUEST_METHOD} !GET'],
+                rewrite_rule => '^ - [FL]'
+              }, {
+                comment      => 'Only allow requests to /(event|place|organizer)s?/<uuid> or /id/(event|place|organizer)/udb/<uuid>',
+                rewrite_cond => [
+                                  '%{REQUEST_URI} !^/(event|place|organizer)s?/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$',
+                                  '%{REQUEST_URI} !^/(event|place|organizer)s?/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$',
+                                  '%{REQUEST_URI} !^/id/(event|place|organizer)/udb/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$',
+                                  '%{REQUEST_URI} !^/id/(event|place|organizer)/udb/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{16}$'
+                                ],
+                rewrite_rule => '^ - [FL]'
+              }, {
+                comment      => 'Reverse proxy /id/(event|place|organizer)/udb/<uuid> to backend',
+                rewrite_cond => [
+                                  '%{REQUEST_URI} "^/id/(event|place|organizer)/udb/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$" [OR]',
+                                  '%{REQUEST_URI} "^/id/(event|place|organizer)/udb/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{16}$"'
+                                ],
+                rewrite_rule => "^/id/(event|place|organizer)/udb/(.*)\$ %{HTTP:X-Forwarded-Proto}://${servername}/\$1s/\$2 [P]"
+              }]
 
-  if $backend_url =~ /^https/ {
-    $https_backend = true
-
-    include apache::mod::ssl
-
-    Class['apache::mod::ssl'] -> Apache::Vhost["${servername}_${port}"]
-  } else {
-    $https_backend = false
+  profiles::apache::vhost::php_fpm { "http://${servername}":
+    basedir               => $basedir,
+    public_web_directory  => 'web',
+    aliases               => [$serveraliases].flatten,
+    allow_encoded_slashes => 'nodecode',
+    access_log_format     => 'extended_json',
+    request_headers       => [
+                               'set Accept "text/turtle"'
+                             ],
+    rewrites              => $rewrites,
+    ssl_proxyengine       => true
   }
 
-  realize Firewall['300 accept HTTP traffic']
-
-  include apache::mod::proxy
-  include apache::mod::proxy_http
-
-  apache::vhost { "${servername}_${port}":
-    servername        => $servername,
-    docroot           => '/var/www/html',
-    manage_docroot    => false,
-    port              => $port,
-    access_log_format => 'extended_json',
-    ssl_proxyengine   => $https_backend,
-    request_headers   => $profiles::apache::defaults::request_headers + [
-                           "setifempty X-Forwarded-Port \"${port}\"",
-                           "setifempty X-Forwarded-Proto \"${transport}\"",
-                           'set Accept "text/turtle"'
-                         ],
-    rewrites          => $rewrites,
-    setenvif          => $profiles::apache::defaults::setenvif,
-    require           => [Class['apache::mod::proxy'], Class['apache::mod::proxy_http']]
+  if $deployment {
+    include profiles::uitdatabank::entry_api::deployment
   }
 
   # include ::profiles::uitdatabank::rdf::monitoring

--- a/spec/classes/uitdatabank/rdf_spec.rb
+++ b/spec/classes/uitdatabank/rdf_spec.rb
@@ -5,113 +5,114 @@ describe 'profiles::uitdatabank::rdf' do
     context "on #{os}" do
       let(:facts) { facts }
 
-      context "with servername => rdf.example.com and backend_url => https://foo.example.com" do
-        let(:params) { {
-          'servername'  => 'rdf.example.com',
-          'backend_url' => 'https://foo.example.com'
-        } }
+      context 'with hieradata' do
+        let(:hiera_config) { 'spec/support/hiera/common.yaml' }
 
-        it { is_expected.to compile.with_all_deps }
+        context "with servername => rdf.example.com" do
+          let(:params) { {
+            'servername' => 'rdf.example.com'
+          } }
 
-        it { is_expected.to contain_firewall('300 accept HTTP traffic') }
-        it { is_expected.to contain_class('profiles::apache') }
+          it { is_expected.to compile.with_all_deps }
 
-        it { is_expected.to contain_class('apache::mod::proxy') }
-        it { is_expected.to contain_class('apache::mod::proxy_http') }
-        it { is_expected.to contain_class('apache::mod::ssl') }
+          it { is_expected.to contain_class('profiles::uitdatabank::rdf').with(
+            'servername'    => 'rdf.example.com',
+            'serveraliases' => [],
+            'deployment'    => true
+          ) }
 
-        it { is_expected.to contain_apache__vhost('rdf.example.com_80').with(
-          'servername'        => 'rdf.example.com',
-          'docroot'           => '/var/www/html',
-          'manage_docroot'    => false,
-          'port'              => 80,
-          'ssl'               => false,
-          'access_log_format' => 'extended_json',
-          'ssl_proxyengine'   => true,
-          'request_headers'   => [
-                                   'unset Proxy early',
-                                   'set X-Unique-Id %{UNIQUE_ID}e',
-                                   'setifempty X-Forwarded-Port "80"',
-                                   'setifempty X-Forwarded-Proto "http"',
-                                   'set Accept "text/turtle"'
-                                 ],
-          'setenvif'          => [
-                                   'X-Forwarded-Proto "https" HTTPS=on',
-                                   'X-Forwarded-For "^([^,]*),?.*" CLIENT_IP=$1'
-                                 ],
-          'rewrites'          => [ {
-                                   'comment'      => 'Reverse proxy /(events|places|organizers)/<uuid> to backend',
-                                   'rewrite_cond' => [
-                                                       '%{REQUEST_URI} "^/(events|places|organizers)/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$" [OR]',
-                                                       '%{REQUEST_URI} "^/(events|places|organizers)/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{16}$"'
-                                                     ],
-                                   'rewrite_rule' => '^/(events|places|organizers)/(.*)$ https://foo.example.com/$1/$2 [P]'
-                                 }, {
-                                   'comment'      => 'Reverse proxy /id/(event|place|organizer)/udb/<uuid> to backend',
-                                   'rewrite_cond' => [
-                                                       '%{REQUEST_URI} "^/id/(event|place|organizer)/udb/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$" [OR]',
-                                                       '%{REQUEST_URI} "^/id/(event|place|organizer)/udb/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{16}$"'
-                                                     ],
-                                   'rewrite_rule' => '^/id/(event|place|organizer)/udb/(.*)$ https://foo.example.com/$1s/$2 [P]'
-                                 } ]
-        ) }
+          it { is_expected.to contain_class('profiles::apache') }
+          it { is_expected.to contain_class('profiles::redis') }
+          it { is_expected.to contain_class('profiles::php') }
 
-        it { is_expected.to contain_class('apache::mod::proxy').that_comes_before('Apache::Vhost[rdf.example.com_80]') }
-        it { is_expected.to contain_class('apache::mod::proxy_http').that_comes_before('Apache::Vhost[rdf.example.com_80]') }
-        it { is_expected.to contain_class('apache::mod::ssl').that_comes_before('Apache::Vhost[rdf.example.com_80]') }
-      end
+          it { is_expected.to contain_profiles__apache__vhost__php_fpm('http://rdf.example.com').with(
+              'basedir'               => '/var/www/udb3-backend',
+              'public_web_directory'  => 'web',
+              'aliases'               => [],
+              'allow_encoded_slashes' => 'nodecode',
+              'access_log_format'     => 'extended_json',
+              'request_headers'       => [
+                                           'set Accept "text/turtle"'
+                                         ],
+              'rewrites'              => [{
+                                           'comment'      => 'Only allow GET requests',
+                                           'rewrite_cond' => [
+                                                               '%{REQUEST_METHOD} !GET'
+                                                             ],
+                                           'rewrite_rule' => '^ - [FL]'
+                                         }, {
+                                           'comment'      => 'Only allow requests to /(event|place|organizer)s?/<uuid> or /id/(event|place|organizer)/udb/<uuid>',
+                                           'rewrite_cond' => [
+                                                               '%{REQUEST_URI} !^/(event|place|organizer)s?/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$',
+                                                               '%{REQUEST_URI} !^/(event|place|organizer)s?/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$',
+                                                               '%{REQUEST_URI} !^/id/(event|place|organizer)/udb/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$',
+                                                               '%{REQUEST_URI} !^/id/(event|place|organizer)/udb/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{16}$'
+                                                             ],
+                                           'rewrite_rule' => '^ - [FL]'
+                                         }, {
+                                           'comment'      => 'Reverse proxy /id/(event|place|organizer)/udb/<uuid> to backend',
+                                           'rewrite_cond' => [
+                                                               '%{REQUEST_URI} "^/id/(event|place|organizer)/udb/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$" [OR]',
+                                                               '%{REQUEST_URI} "^/id/(event|place|organizer)/udb/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{16}$"'
+                                                             ],
+                                           'rewrite_rule' => '^/id/(event|place|organizer)/udb/(.*)$ %{HTTP:X-Forwarded-Proto}://rdf.example.com/$1s/$2 [P]'
+                                         }],
+            'ssl_proxyengine'         => true
+          ) }
+        end
 
-      context "with servername => foo.example.com and backend_url => http://bar.example.com/" do
-        let(:params) { {
-          'servername'  => 'foo.example.com',
-          'backend_url' => 'http://bar.example.com/'
-        } }
+        context "with servername => foo.example.com, serveraliases => [bar.example.com, baz.example.com] and deployment => false" do
+          let(:params) { {
+            'servername'    => 'foo.example.com',
+            'serveraliases' => ['bar.example.com', 'baz.example.com'],
+            'deployment'    => false
+          } }
 
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.not_to contain_class('apache::mod::ssl') }
+          it { is_expected.to compile.with_all_deps }
 
-        it { is_expected.to contain_apache__vhost('foo.example.com_80').with(
-          'servername'        => 'foo.example.com',
-          'docroot'           => '/var/www/html',
-          'manage_docroot'    => false,
-          'port'              => 80,
-          'ssl'               => false,
-          'access_log_format' => 'extended_json',
-          'ssl_proxyengine'   => false,
-          'request_headers'   => [
-                                   'unset Proxy early',
-                                   'set X-Unique-Id %{UNIQUE_ID}e',
-                                   'setifempty X-Forwarded-Port "80"',
-                                   'setifempty X-Forwarded-Proto "http"',
-                                   'set Accept "text/turtle"'
-                                 ],
-          'setenvif'          => [
-                                   'X-Forwarded-Proto "https" HTTPS=on',
-                                   'X-Forwarded-For "^([^,]*),?.*" CLIENT_IP=$1'
-                                 ],
-          'rewrites'          => [ {
-                                   'comment'      => 'Reverse proxy /(events|places|organizers)/<uuid> to backend',
-                                   'rewrite_cond' => [
-                                                     '%{REQUEST_URI} "^/(events|places|organizers)/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$" [OR]',
-                                                     '%{REQUEST_URI} "^/(events|places|organizers)/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{16}$"'
-                                                   ],
-                                   'rewrite_rule' => '^/(events|places|organizers)/(.*)$ http://bar.example.com/$1/$2 [P]'
-                                 }, {
-                                   'comment'      => 'Reverse proxy /id/(event|place|organizer)/udb/<uuid> to backend',
-                                   'rewrite_cond' => [
-                                                     '%{REQUEST_URI} "^/id/(event|place|organizer)/udb/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$" [OR]',
-                                                     '%{REQUEST_URI} "^/id/(event|place|organizer)/udb/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{16}$"'
-                                                   ],
-                                   'rewrite_rule' => '^/id/(event|place|organizer)/udb/(.*)$ http://bar.example.com/$1s/$2 [P]'
-                                 } ]
-        ) }
+          it { is_expected.not_to contain_class('profiles::uitdatabank::entry_api::deployment') }
+
+          it { is_expected.to contain_profiles__apache__vhost__php_fpm('http://foo.example.com').with(
+              'basedir'               => '/var/www/udb3-backend',
+              'public_web_directory'  => 'web',
+              'aliases'               => ['bar.example.com', 'baz.example.com'],
+              'allow_encoded_slashes' => 'nodecode',
+              'access_log_format'     => 'extended_json',
+              'request_headers'       => [
+                                           'set Accept "text/turtle"'
+                                         ],
+              'rewrites'              => [{
+                                           'comment'      => 'Only allow GET requests',
+                                           'rewrite_cond' => [
+                                                               '%{REQUEST_METHOD} !GET'
+                                                             ],
+                                           'rewrite_rule' => '^ - [FL]'
+                                         }, {
+                                           'comment'      => 'Only allow requests to /(event|place|organizer)s?/<uuid> or /id/(event|place|organizer)/udb/<uuid>',
+                                           'rewrite_cond' => [
+                                                               '%{REQUEST_URI} !^/(event|place|organizer)s?/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$',
+                                                               '%{REQUEST_URI} !^/(event|place|organizer)s?/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$',
+                                                               '%{REQUEST_URI} !^/id/(event|place|organizer)/udb/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$',
+                                                               '%{REQUEST_URI} !^/id/(event|place|organizer)/udb/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{16}$'
+                                                             ],
+                                           'rewrite_rule' => '^ - [FL]'
+                                         }, {
+                                           'comment'      => 'Reverse proxy /id/(event|place|organizer)/udb/<uuid> to backend',
+                                           'rewrite_cond' => [
+                                                               '%{REQUEST_URI} "^/id/(event|place|organizer)/udb/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$" [OR]',
+                                                               '%{REQUEST_URI} "^/id/(event|place|organizer)/udb/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{16}$"'
+                                                             ],
+                                           'rewrite_rule' => '^/id/(event|place|organizer)/udb/(.*)$ %{HTTP:X-Forwarded-Proto}://foo.example.com/$1s/$2 [P]'
+                                         }],
+            'ssl_proxyengine'         => true
+          ) }
+        end
       end
 
       context "without parameters" do
         let(:params) { {} }
 
         it { expect { catalogue }.to raise_error(Puppet::ParseError, /expects a value for parameter 'servername'/) }
-        it { expect { catalogue }.to raise_error(Puppet::ParseError, /expects a value for parameter 'backend_url'/) }
       end
     end
   end


### PR DESCRIPTION
### Changed

- Only allow GET requests to specific endpoints on the RDF vhost
- Deploy UiTdatabank entry API
- Process the allowed requests instead of proxying to the actual UiTdatabank entry API

---
Ticket: https://jira.uitdatabank.be/browse/III-6632
