### PR TITLE
Add proxy_http module when proxy flags is present in rewrites for PHP fpm vhost

### DIFF
--- a/manifests/uitdatabank/rdf.pp
+++ b/manifests/uitdatabank/rdf.pp
@@ -13,7 +13,7 @@ class profiles::uitdatabank::rdf (
   $rewrites = [{
                 comment      => 'Only allow GET requests',
                 rewrite_cond => ['%{REQUEST_METHOD} !GET'],
-                rewrite_rule => '^ - [FL]'
+                rewrite_rule => '^ - [F,L]'
               }, {
                 comment      => 'Only allow requests to /(event|place|organizer)s?/<uuid> or /id/(event|place|organizer)/udb/<uuid>',
                 rewrite_cond => [
@@ -22,7 +22,7 @@ class profiles::uitdatabank::rdf (
                                   '%{REQUEST_URI} !^/id/(event|place|organizer)/udb/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$',
                                   '%{REQUEST_URI} !^/id/(event|place|organizer)/udb/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{16}$'
                                 ],
-                rewrite_rule => '^ - [FL]'
+                rewrite_rule => '^ - [F,L]'
               }, {
                 comment      => 'Reverse proxy /id/(event|place|organizer)/udb/<uuid> to backend',
                 rewrite_cond => [

--- a/spec/classes/uitdatabank/rdf_spec.rb
+++ b/spec/classes/uitdatabank/rdf_spec.rb
@@ -39,7 +39,7 @@ describe 'profiles::uitdatabank::rdf' do
                                            'rewrite_cond' => [
                                                                '%{REQUEST_METHOD} !GET'
                                                              ],
-                                           'rewrite_rule' => '^ - [FL]'
+                                           'rewrite_rule' => '^ - [F,L]'
                                          }, {
                                            'comment'      => 'Only allow requests to /(event|place|organizer)s?/<uuid> or /id/(event|place|organizer)/udb/<uuid>',
                                            'rewrite_cond' => [
@@ -48,7 +48,7 @@ describe 'profiles::uitdatabank::rdf' do
                                                                '%{REQUEST_URI} !^/id/(event|place|organizer)/udb/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$',
                                                                '%{REQUEST_URI} !^/id/(event|place|organizer)/udb/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{16}$'
                                                              ],
-                                           'rewrite_rule' => '^ - [FL]'
+                                           'rewrite_rule' => '^ - [F,L]'
                                          }, {
                                            'comment'      => 'Reverse proxy /id/(event|place|organizer)/udb/<uuid> to backend',
                                            'rewrite_cond' => [
@@ -86,7 +86,7 @@ describe 'profiles::uitdatabank::rdf' do
                                            'rewrite_cond' => [
                                                                '%{REQUEST_METHOD} !GET'
                                                              ],
-                                           'rewrite_rule' => '^ - [FL]'
+                                           'rewrite_rule' => '^ - [F,L]'
                                          }, {
                                            'comment'      => 'Only allow requests to /(event|place|organizer)s?/<uuid> or /id/(event|place|organizer)/udb/<uuid>',
                                            'rewrite_cond' => [
@@ -95,7 +95,7 @@ describe 'profiles::uitdatabank::rdf' do
                                                                '%{REQUEST_URI} !^/id/(event|place|organizer)/udb/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$',
                                                                '%{REQUEST_URI} !^/id/(event|place|organizer)/udb/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{16}$'
                                                              ],
-                                           'rewrite_rule' => '^ - [FL]'
+                                           'rewrite_rule' => '^ - [F,L]'
                                          }, {
                                            'comment'      => 'Reverse proxy /id/(event|place|organizer)/udb/<uuid> to backend',
                                            'rewrite_cond' => [


### PR DESCRIPTION
### Changed

- Separate rewrite flags with a comma
- Add proxy_http module when proxy flag is present in rewrites for PHP fpm vhost

---
Ticket: https://jira.uitdatabank.be/browse/III-6632
