### PR TITLE
Do not enable the event-export-workers target when target count is 0

### DIFF
--- a/manifests/uitdatabank/entry_api/event_export_workers.pp
+++ b/manifests/uitdatabank/entry_api/event_export_workers.pp
@@ -34,7 +34,10 @@ class profiles::uitdatabank::entry_api::event_export_workers (
                     0       => 'stopped',
                     default => 'running'
                   },
-    enable     => true,
+    enable     => $count ? {
+                    0       => false,
+                    default => true
+                  },
     hasstatus  => true,
     hasrestart => false,
     require    => [Group['www-data'], User['www-data'], Systemd::Daemon_reload['uitdatabank-event-export-workers.target']]

--- a/spec/classes/uitdatabank/entry_api/event_export_workers_spec.rb
+++ b/spec/classes/uitdatabank/entry_api/event_export_workers_spec.rb
@@ -86,7 +86,8 @@ describe 'profiles::uitdatabank::entry_api::event_export_workers' do
         ) }
 
         it { is_expected.to contain_service('uitdatabank-event-export-workers.target').with(
-          'ensure' => 'stopped'
+          'ensure' => 'stopped',
+          'enable' => 'false'
         ) }
 
         it { is_expected.to contain_file('uitdatabank_event_export_worker_count_external_fact').with(


### PR DESCRIPTION
### Changed

- Do not enable the event-export-workers target when target count is 0

---
Ticket: https://jira.uitdatabank.be/browse/III-6632
