### PR TITLE
Adds Terraform per-role data lookup

### DIFF
--- a/manifests/puppet/puppetserver/hiera.pp
+++ b/manifests/puppet/puppetserver/hiera.pp
@@ -20,6 +20,7 @@ class profiles::puppet::puppetserver::hiera (
   $terraform_lookup_hierarchy = $terraform_integration ? {
                                   true  => [
                                              { 'name' => 'Terraform per-node data', 'glob' => 'terraform/%{::trusted.certname}/*.yaml' },
+                                             { 'name' => 'Terraform per-role data', 'glob' => 'terraform/role-%%{}{::trusted.extensions.pp_role}/*.yaml' },
                                              { 'name' => 'Terraform common data', 'path' => 'terraform/common.yaml' }
                                            ],
                                   false => []

--- a/spec/classes/puppet/puppetserver/hiera_spec.rb
+++ b/spec/classes/puppet/puppetserver/hiera_spec.rb
@@ -18,6 +18,7 @@ describe 'profiles::puppet::puppetserver::hiera' do
             'gpg_key'               => {},
             'lookup_hierarchy'      => [
                                          { 'name' => 'Per-node data', 'path' => 'nodes/%{::trusted.certname}.yaml' },
+                                         { 'name' => 'Terraform per-role data', 'glob' => 'terraform/role-%%{}{::trusted.extensions.pp_role}/*.yaml' },
                                          { 'name' => 'Common data', 'path' => 'common.yaml' }
                                        ],
             'terraform_integration' => false,


### PR DESCRIPTION
Adds a new level of hierarchy to the Hiera configuration allowing lookups based on the Puppet role assigned to a node. 

