### PR TITLE
Refactor sling profile

### DIFF
--- a/manifests/platform.pp
+++ b/manifests/platform.pp
@@ -57,12 +57,12 @@ class profiles::platform (
       require   => Profiles::Mysql::App_user["${database_user}@${database_name}"],
       subscribe => Class['profiles::php']
     }
-  }
 
-  if $sling_enabled {
-    class { 'profiles::sling':
-      version                 => 'latest',
-      database_name           => 'platform'
-     }
+    if $sling_enabled {
+      class { 'profiles::platform::sling':
+        database_name => $database_name,
+        require       => Class['profiles::platform::deployment']
+      }
+    }
   }
 }

--- a/manifests/platform/sling.pp
+++ b/manifests/platform/sling.pp
@@ -1,4 +1,4 @@
-class profiles::sling (
+class profiles::platform::sling (
   String $version                  = 'latest',
   Optional[String] $database_name  = undef,
   Optional[String] $project_id     = undef,

--- a/spec/classes/platform_spec.rb
+++ b/spec/classes/platform_spec.rb
@@ -56,6 +56,8 @@ describe 'profiles::platform' do
 
             it { is_expected.to contain_class('profiles::platform::deployment') }
 
+            it { is_expected.not_to contain_class('profiles::platform::sling') }
+
             it { is_expected.to contain_profiles__apache__vhost__php_fpm('http://platform.example.com').with(
               'basedir'              => '/var/www/platform-api',
               'public_web_directory' => 'public',
@@ -98,6 +100,8 @@ describe 'profiles::platform' do
 
           it { is_expected.not_to contain_class('profiles::platform::deployment') }
 
+          it { is_expected.not_to contain_class('profiles::platform::sling') }
+
           it { is_expected.to contain_class('profiles::mailpit').with(
             'smtp_address' => '127.0.0.1',
             'smtp_port'    => 1025,
@@ -111,6 +115,27 @@ describe 'profiles::platform' do
             'aliases'              => ['foo.example.com', 'bar.example.com'],
             'socket_type'          => 'tcp'
           ) }
+        end
+      end
+
+      context 'with database_password => foo, servername => myplatform.example.com, catch_mail => false and sling_enabled => true' do
+        let(:params) { {
+          'database_password' => 'foo',
+          'servername'        => 'myplatform.example.com',
+          'catch_mail'        => false,
+          'sling_enabled'     => true
+        } }
+
+        context 'with hieradata' do
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+          it { is_expected.to contain_class('profiles::platform::sling').with(
+            'database_name' => 'platform'
+          ) }
+
+          it { is_expected.not_to contain_class('profiles::mailpit') }
+
+          it { is_expected.to contain_class('profiles::platform::sling').that_requires('Class[profiles::platform::deployment]') }
         end
       end
 


### PR DESCRIPTION
### Changed

- Move profiles::sling to profiles::platform::sling as it contains some
  publiq platform specific code. Future commits will split it up and make
  it more general.
