### PR TITLE
Update app name for Glassfish

### DIFF
--- a/manifests/uitid/mailing/deployment.pp
+++ b/manifests/uitid/mailing/deployment.pp
@@ -12,7 +12,7 @@ class profiles::uitid::mailing::deployment (
   realize Apt::Source[$repository]
   realize User['glassfish']
 
-  package { 'uitid-mailing':
+  package { 'cultuurnet-mailing-app':
     ensure  => $version,
     require => Apt::Source[$repository],
     notify  => [App['uitid-mailing']],
@@ -24,7 +24,7 @@ class profiles::uitid::mailing::deployment (
     passwordfile  => '/home/glassfish/asadmin.pass',
     contextroot   => 'mailing',
     precompilejsp => false,
-    source        => '/opt/uitid-mailing/uitid-mailing.war',
+    source        => '/opt/cultuurnet-mailing-app/cultuurnet-mailing-app.war',
     require       => [User['glassfish']],
   }
 }


### PR DESCRIPTION
This pull request updates the deployment configuration for the mailing application to reflect a name change from `uitid-mailing` to `cultuurnet-mailing-app`. The changes ensure consistency in the application naming and file paths.

### Deployment configuration updates:

* Renamed the package from `uitid-mailing` to `cultuurnet-mailing-app` in the `package` resource definition. (`manifests/uitid/mailing/deployment.pp`, [manifests/uitid/mailing/deployment.ppL15-R15](diffhunk://#diff-b8b2b78a72198a41c9b4c7efa90a6b2354e90b9edf46f7de47995db32b4ca225L15-R15))
* Updated the source path for the `.war` file to use the new application name (`cultuurnet-mailing-app`) in the deployment configuration. (`manifests/uitid/mailing/deployment.pp`, [manifests/uitid/mailing/deployment.ppL27-R27](diffhunk://#diff-b8b2b78a72198a41c9b4c7efa90a6b2354e90b9edf46f7de47995db32b4ca225L27-R27))