### PR TITLE
Skip sling concat for now

### DIFF
--- a/manifests/sling.pp
+++ b/manifests/sling.pp
@@ -11,15 +11,15 @@ class profiles::sling inherits ::profiles {
     ensure => 'directory'
   }
 
-  concat { '/root/.sling/env.yaml':
-    ensure  => 'present',
-    order   => 'numeric',
-    require => File['/root/.sling']
-  }
+  # concat { '/root/.sling/env.yaml':
+  #   ensure  => 'present',
+  #   order   => 'numeric',
+  #   require => File['/root/.sling']
+  # }
 
-  concat::fragment { 'sling_connections_header':
-    target  => '/root/.sling/env.yaml',
-    content => "connections:\n",
-    order   => 1
-  }
+  # concat::fragment { 'sling_connections_header':
+  #   target  => '/root/.sling/env.yaml',
+  #   content => "connections:\n",
+  #   order   => 1
+  # }
 }


### PR DESCRIPTION
Sets up a directory for environment configuration.

### Added

-

### Changed

- Sling profile concat function disabled

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
