### PR TITLE
Update reverse proxy with gcp int, cronjob and updated firewall rules

### DIFF
--- a/manifests/uitid/reverse_proxy.pp
+++ b/manifests/uitid/reverse_proxy.pp
@@ -62,4 +62,13 @@ class profiles::uitid::reverse_proxy (
     path   => "${basedir}/sites-enabled/uitid-proxy.conf",
     target => "${basedir}/sites-available/uitid-proxy.conf",
   }
+
+  cron { 'gsutil_rsync_nginx_logs':
+    ensure  => present,
+    environment => ['MAILTO=infra+cron@publiq.be'],
+    command => '/usr/bin/gsutil rsync -x ".*error.*|.*log$|uitpas-prod.uitid.*|^access.log.*" /var/log/nginx/ gs://publiq-etl-prod/etl/rev_proxy_logs/raw/',
+    user    => 'root',
+    minute  => 45,
+    hour    => 7,
+  }
 }


### PR DESCRIPTION
This pull request introduces support for syncing Nginx logs from the reverse proxy to Google Cloud Storage (GCS) as part of the ETL process. It adds configuration options and resources for enabling this feature, including Google Cloud credentials management and a scheduled cron job for log syncing.

**Google Cloud ETL sync integration:**

* Added a new parameter `gcloud_etl_sync_enabled` (default: `true`) to the `reverse_proxy` manifest, allowing control over whether GCS syncing is enabled.
* When enabled, retrieves Google Cloud credentials from Vault and configures the `profiles::google::gcloud` resource for authentication.

**Log syncing automation:**

* Introduced a cron job (`gsutil_rsync_nginx_logs`) that runs daily at 7:45 AM as root, syncing Nginx logs to the GCS bucket `publiq-etl-prod/etl/rev_proxy_logs/raw/` while excluding error logs and specific files.

**Firewall configuration:**

* Ensures the firewall rule for accepting HTTP traffic is realized, in addition to the existing HTTPS rule, to support  proxy operations.