### PR TITLE
Do not enable cron if etl sync is disabled

### DIFF
--- a/manifests/uitid/reverse_proxy.pp
+++ b/manifests/uitid/reverse_proxy.pp
@@ -63,12 +63,14 @@ class profiles::uitid::reverse_proxy (
     target => "${basedir}/sites-available/uitid-proxy.conf",
   }
 
-  cron { 'gsutil_rsync_nginx_logs':
-    ensure  => present,
-    environment => ['MAILTO=infra+cron@publiq.be'],
-    command => '/usr/bin/gsutil rsync -x ".*error.*|.*log$|uitpas-prod.uitid.*|^access.log.*" /var/log/nginx/ gs://publiq-etl-prod/etl/rev_proxy_logs/raw/',
-    user    => 'root',
-    minute  => 45,
-    hour    => 7,
+  if $gcloud_etl_sync_enabled {
+    cron { 'gsutil_rsync_nginx_logs':
+      ensure      => present,
+      environment => ['MAILTO=infra+cron@publiq.be'],
+      command     => '/usr/bin/gsutil rsync -x ".*error.*|.*log$|uitpas-prod.uitid.*|^access.log.*" /var/log/nginx/ gs://publiq-etl-prod/etl/rev_proxy_logs/raw/',
+      user        => 'root',
+      minute      => 45,
+      hour        => 7,
+    }
   }
 }

--- a/manifests/uitid/reverse_proxy.pp
+++ b/manifests/uitid/reverse_proxy.pp
@@ -63,14 +63,15 @@ class profiles::uitid::reverse_proxy (
     target => "${basedir}/sites-available/uitid-proxy.conf",
   }
 
-  if $gcloud_etl_sync_enabled {
-    cron { 'gsutil_rsync_nginx_logs':
-      ensure      => present,
-      environment => ['MAILTO=infra+cron@publiq.be'],
-      command     => '/usr/bin/gsutil rsync -x ".*error.*|.*log$|uitpas-prod.uitid.*|^access.log.*" /var/log/nginx/ gs://publiq-etl-prod/etl/rev_proxy_logs/raw/',
-      user        => 'root',
-      minute      => 45,
-      hour        => 7,
-    }
+  cron { 'gsutil_rsync_nginx_logs':
+    ensure       => $gcloud_etl_sync_enabled ? {
+      true  => 'present',
+      false => 'absent'
+    },
+    environment => ['MAILTO=infra+cron@publiq.be'],
+    command    => '/usr/bin/gsutil rsync -x ".*error.*|.*log$|uitpas-prod.uitid.*|^access.log.*" /var/log/nginx/ gs://publiq-etl-prod/etl/rev_proxy_logs/raw/',
+    user       => 'root',
+    minute     => 45,
+    hour       => 7,
   }
 }

--- a/manifests/uitpas/segmentatie/deployment.pp
+++ b/manifests/uitpas/segmentatie/deployment.pp
@@ -24,7 +24,7 @@ class profiles::uitpas::segmentatie::deployment (
   if $cron_enabled {
     cron { 'uitpas-segmentatie-sync':
       ensure  => 'present',
-      command => "/usr/bin/curl -X POST 'http://127.0.0.1:${glassfish_domain_http_port}/segmentation/rest/sync",
+      command => "/usr/bin/curl -X POST 'http://127.0.0.1:${glassfish_domain_http_port}/segmentation/rest/sync'",
       user    => 'www-data',
       hour    => 1,
       minute  => 45,


### PR DESCRIPTION
### Added

-

### Changed

- Do not enable cron for log sync  if etl sync is disabled

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
