### PR TITLE
Adds reverse proxy for Elasticsearch

### DIFF
--- a/manifests/uitdatabank/es_performance.pp
+++ b/manifests/uitdatabank/es_performance.pp
@@ -1,0 +1,16 @@
+class profiles::uitdatabank::es_performance (
+  String                         $servername,
+  Variant[String, Array[String]] $serveraliases            = [],
+  Optional[String]               $elasticsearch_servername = undef,
+) inherits ::profiles {
+
+
+  include profiles::elasticsearch
+
+
+  if $elasticsearch_servername {
+    profiles::apache::vhost::reverse_proxy { "http://${elasticsearch_servername}":
+      destination => 'http://127.0.0.1:9200/'
+    }
+  }
+}


### PR DESCRIPTION
Introduces a class to configure a reverse proxy to Elasticsearch via Apache.

This class allows specifying an external server name for Elasticsearch, and sets up a reverse proxy to forward requests to the local Elasticsearch instance.

### Added

-

### Changed

-

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
