### PR TITLE
Disable xpack on ElasticSearch 8 and above

### DIFF
--- a/spec/classes/elasticsearch_spec.rb
+++ b/spec/classes/elasticsearch_spec.rb
@@ -63,7 +63,8 @@ describe 'profiles::elasticsearch' do
           'manage_datadir'    => false,
           'manage_logdir'     => true,
           'init_defaults'     => { 'ES_JAVA_OPTS' => '"-Xms512m -Xmx512m"' },
-          'jvm_options'       => ['-XX:+IgnoreUnrecognizedVMOptions']
+          'jvm_options'       => ['-XX:+IgnoreUnrecognizedVMOptions'],
+          'config'            => {}
         ) }
 
         it { is_expected.to contain_class('profiles::elasticsearch::backup').with(
@@ -92,7 +93,7 @@ describe 'profiles::elasticsearch' do
         it { is_expected.not_to contain_class('profiles::elasticsearch::backup') }
       end
 
-      context "with version => 8.2.1, lvm => true, volume_group => myvg, volume_size => 20G, log_volume_size => 5G, initial_heap_size => 768m, maximum_heap_size => 1024m, backup_lvm => true, backup_volume_group => mybackupvg, backup_volume_size => 10G, backup_hour => 10 and backup_retention_days =>5" do
+      context "with version => 8.2.1, lvm => true, volume_group => myvg, volume_size => 20G, log_volume_size => 5G, initial_heap_size => 768m, maximum_heap_size => 1024m, backup_lvm => true, backup_volume_group => mybackupvg, backup_volume_size => 10G, backup_hour => 10, backup_retention_days => 5 and jvm_options => -Xmixed" do
         let(:params) { {
           'version'               => '8.2.1',
           'lvm'                   => true,
@@ -105,7 +106,8 @@ describe 'profiles::elasticsearch' do
           'backup_volume_group'   => 'mybackupvg',
           'backup_volume_size'    => '10G',
           'backup_hour'           => 10,
-          'backup_retention_days' => 5
+          'backup_retention_days' => 5,
+          'jvm_options'           => '-Xmixed'
         } }
 
         context "with volume_groups myvg and mybackupvg present" do
@@ -165,7 +167,13 @@ describe 'profiles::elasticsearch' do
             'datadir'           => '/var/lib/elasticsearch',
             'manage_datadir'    => false,
             'manage_logdir'     => false,
-            'init_defaults'     => { 'ES_JAVA_OPTS' => '"-Xms768m -Xmx1024m"' }
+            'init_defaults'     => { 'ES_JAVA_OPTS' => '"-Xms768m -Xmx1024m"' },
+            'jvm_options'       => ['-XX:+IgnoreUnrecognizedVMOptions', '-Xmixed'],
+            'config'            => {
+                                     'xpack.security.enabled'               => false,
+                                     'xpack.security.transport.ssl.enabled' => false,
+                                     'xpack.security.http.ssl.enabled'      => false
+                                   }
           ) }
 
           it { is_expected.to contain_class('profiles::elasticsearch::backup').with(
@@ -196,7 +204,7 @@ describe 'profiles::elasticsearch' do
         end
       end
 
-      context "with version => 5.2.2, lvm => true, volume_group => mydatavg, volume_size => 10G, backup_lvm => true, backup_volume_group => esbackupvg, backup_volume_size => 5G, backup_hour => 1 and backup_retention_days => 10" do
+      context "with version => 5.2.2, lvm => true, volume_group => mydatavg, volume_size => 10G, backup_lvm => true, backup_volume_group => esbackupvg, backup_volume_size => 5G, backup_hour => 1, backup_retention_days => 10 and jvm_options => [-Xmixed, -Xverify]" do
         let(:params) { {
           'version'               => '5.2.2',
           'lvm'                   => true,
@@ -206,7 +214,8 @@ describe 'profiles::elasticsearch' do
           'backup_volume_group'   => 'esbackupvg',
           'backup_volume_size'    => '5G',
           'backup_hour'           => 1,
-          'backup_retention_days' => 10
+          'backup_retention_days' => 10,
+          'jvm_options'           => ['-Xmixed', '-Xverify']
         } }
 
         context "with volume_groups mydatavg and esbackupvg present" do
@@ -241,7 +250,8 @@ describe 'profiles::elasticsearch' do
             'datadir'           => '/var/lib/elasticsearch',
             'manage_datadir'    => false,
             'manage_logdir'     => true,
-            'init_defaults'     => { 'ES_JAVA_OPTS' => '"-Xms512m -Xmx512m"' }
+            'init_defaults'     => { 'ES_JAVA_OPTS' => '"-Xms512m -Xmx512m"' },
+            'jvm_options'       => ['-XX:+IgnoreUnrecognizedVMOptions', '-Xmixed', '-Xverify']
           ) }
 
           it { is_expected.to contain_class('profiles::elasticsearch::backup').with(


### PR DESCRIPTION
- **Allow specifying jvm_options on ES profile and add default to ignore unknown VM options**
- **Disable xpack on ElasticSearch 8 and above**
