### PR TITLE
Updates service health check URLs

### DIFF
--- a/templates/uitpas/api/deployment/service_healthcheck.erb
+++ b/templates/uitpas/api/deployment/service_healthcheck.erb
@@ -1,8 +1,8 @@
 
 
-HEALTH_URL="https://localhost:<%= @https_port_base %>/uitid/rest/uitpas/health"
-CARDSYSTEM_HEALTH_URL="https://localhost:<%= @https_port_base %>/uitid/rest/cardsystem/login"
-/usr/bin/test $(curl -s -k -o /dev/null $HEALTH_URL -w "%{http_code}") -eq 200  || return 1
-/usr/bin/test $(curl -s -k -o /dev/null $CARDSYSTEM_HEALTH_URL -w "%{http_code}") -eq 200
+HEALTH_URL="http://localhost:<%= @http_port_base %>/uitid/rest/uitpas/health"
+CARDSYSTEM_HEALTH_URL="http://localhost:<%= @http_port_base %>/uitid/rest/cardsystem/login"
+/usr/bin/test $(/usr/bin/curl -s  -o /dev/null $HEALTH_URL -w "%{http_code}") -eq 200  || return 1
+/usr/bin/test $(/usr/bin/curl -s  -o /dev/null $CARDSYSTEM_HEALTH_URL -w "%{http_code}") -eq 200
 
 


### PR DESCRIPTION
Updates the service health check to use HTTP instead of HTTPS.

Removes certificate verification from health check requests.

### Added

-

### Changed

-

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
