### PR TITLE
Increases timeout for service health check

### DIFF
--- a/manifests/uitpas/api/deployment.pp
+++ b/manifests/uitpas/api/deployment.pp
@@ -54,7 +54,7 @@ class profiles::uitpas::api::deployment (
       false => 'absent'
     },
     check_interval_seconds => 20,
-    timeout_seconds        => 120,
+    timeout_seconds        => 160,
     healthcheck            => template('profiles/uitpas/api/deployment/service_healthcheck.erb'),
   }
   profiles::deployment::versions { $title:


### PR DESCRIPTION
Increases the timeout to allow more time for the service health check to complete, preventing false alarms.

### Added

-

### Changed

-

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
