### PR TITLE
Add dynamic magda certs to UiTPAS using puppet

### DIFF
--- a/manifests/uitpas/api.pp
+++ b/manifests/uitpas/api.pp
@@ -8,6 +8,12 @@ class profiles::uitpas::api (
   Optional[String]               $maximum_heap_size    = undef,
   Boolean                        $jmx                  = true,
   Boolean                        $newrelic             = false,
+  String                         $magda_sftp_path,
+  String                         $magda_sftp_cert,
+  String                         $magda_sftp_key,
+  String                         $magda_soap_path,
+  String                         $magda_soap_keystore,
+  String                         $magda_soap_truststore,
   Optional[String]               $newrelic_license_key = lookup('data::newrelic::license_key', Optional[String], 'first', undef),
   Integer                        $portbase             = 4800,
   Enum['running', 'stopped']     $service_status       = 'running',
@@ -25,10 +31,59 @@ class profiles::uitpas::api (
   include profiles::apache
   include profiles::java
   include profiles::glassfish
+  include openssl
+
+  $secrets = lookup('vault:uit/api')
+
+  $magda_sftp_certpath = "${magda_sftp_path}/${magda_sftp_cert}"
+  $magda_sftp_keypath  = "${magda_sftp_path}/${magda_sftp_key}"
+  $magda_soap_keystorepath = "${magda_soap_path}/${magda_soap_keystore}"
+  $magda_soap_truststorepath  = "${magda_soap_path}/${magda_soap_truststore}"
+
+  file { "${magda_soap_path}":
+    ensure => 'directory',
+    owner  => 'glassfish',
+    group  => 'glassfish',
+    mode   => '0755',
+  }
+  file { "${magda_sftp_path}":
+    ensure => 'directory',
+    owner  => 'glassfish',
+    group  => 'glassfish',
+    mode   => '0755',
+  }
+  file { "${magda_sftp_certpath}":
+    ensure  => 'file',
+    content => $secrets["magda-sftp-crt"],
+    owner   => 'glassfish',
+    group   => 'glassfish',
+    mode    => '0644',
+  }
+  file { "${magda_sftp_keypath}":
+    ensure  => 'file',
+    content => $secrets["magda-sftp-key"],
+    owner   => 'glassfish',
+    group   => 'glassfish',
+    mode    => '0600',
+  }
+  file { '/tmp/magda-soap-cert.crt':
+    ensure  => 'file',
+    content => $secrets["magda-soap-crt"],
+    owner   => 'glassfish',
+    group   => 'glassfish',
+    mode    => '0644',
+  }
+  file { '/tmp/magda-soap-key.pem':
+    ensure  => 'file',
+    content => $secrets["magda-soap-key"],
+    owner   => 'glassfish',
+    group   => 'glassfish',
+    mode    => '0600',
+  }
 
   profiles::apache::vhost::reverse_proxy { "http://${servername}":
     destination => "http://127.0.0.1:${glassfish_domain_http_port}/uitid/rest/",
-    aliases     => $serveraliases
+    aliases     => $serveraliases,
   }
 
   if $database_host == '127.0.0.1' {
@@ -69,33 +124,33 @@ class profiles::uitpas::api (
     newrelic_license_key => $newrelic_license_key,
     service_status       => $service_status,
     require              => Class['profiles::glassfish'],
-    notify               => Service['uitpas']
+    notify               => Service['uitpas'],
   }
 
   if $database_host_available {
     mysql_database { $database_name:
       charset => 'utf8mb4',
-      collate => 'utf8mb4_unicode_ci'
+      collate => 'utf8mb4_unicode_ci',
     }
 
     profiles::mysql::app_user { "${database_user}@${database_name}":
       password => $database_password,
       remote   => $database_host_remote,
-      require  => Mysql_database[$database_name]
+      require  => Mysql_database[$database_name],
     }
 
     profiles::mysql::app_user { "etl@${database_name}":
       password => lookup('data::mysql::etl::password', Optional[String], 'first', undef),
       readonly => true,
       remote   => $database_host_remote,
-      require  => Mysql_database[$database_name]
+      require  => Mysql_database[$database_name],
     }
 
     profiles::mysql::app_user { "2ndline_ro@${database_name}":
       password => lookup('data::mysql::2ndline_ro::password', Optional[String], 'first', undef),
       readonly => true,
       remote   => $database_host_remote,
-      require  => Mysql_database[$database_name]
+      require  => Mysql_database[$database_name],
     }
 
     jdbcconnectionpool { 'mysql_uitpas_api_j2eePool':
@@ -112,17 +167,17 @@ class profiles::uitpas::api (
         'driverClass'       => 'com.mysql.cj.jdbc.Driver',
         'characterEncoding' => 'UTF-8',
         'useUnicode'        => true,
-        'useSSL'            => false
+        'useSSL'            => false,
       },
       require      => [Profiles::Glassfish::Domain['uitpas'], Profiles::Mysql::App_user["${database_user}@${database_name}"]],
-      *            => $default_attributes
+      *            => $default_attributes,
     }
 
     jdbcresource { 'jdbc/cultuurnet_uitpas':
       ensure         => 'present',
       connectionpool => 'mysql_uitpas_api_j2eePool',
       require        => Jdbcconnectionpool['mysql_uitpas_api_j2eePool'],
-      *              => $default_attributes
+      *              => $default_attributes,
     }
 
     if $deployment {
@@ -134,7 +189,7 @@ class profiles::uitpas::api (
 
       class { 'profiles::uitpas::api::cron':
         portbase => $portbase,
-        require  => Class['profiles::uitpas::api::deployment']
+        require  => Class['profiles::uitpas::api::deployment'],
       }
 
       Class['profiles::glassfish'] -> Class['profiles::uitpas::api::deployment']
@@ -151,7 +206,7 @@ class profiles::uitpas::api (
     value   => 'X-Forwarded-Proto',
     require => Profiles::Glassfish::Domain['uitpas'],
     notify  => Service['uitpas'],
-    *       => $default_attributes
+    *       => $default_attributes,
   }
 
   set { 'server.thread-pools.thread-pool.http-thread-pool.max-thread-pool-size':
@@ -159,7 +214,7 @@ class profiles::uitpas::api (
     value   => '32',
     require => Profiles::Glassfish::Domain['uitpas'],
     notify  => Service['uitpas'],
-    *       => $default_attributes
+    *       => $default_attributes,
   }
 
   jvmoption { 'Clear domain uitpas default truststore':
@@ -167,7 +222,7 @@ class profiles::uitpas::api (
     option  => '-Djavax.net.ssl.trustStore=\$\{com.sun.aas.instanceRoot\}/config/cacerts.jks',
     require => Profiles::Glassfish::Domain['uitpas'],
     notify  => Service['uitpas'],
-    *       => $default_attributes
+    *       => $default_attributes,
   }
 
   jvmoption { 'Domain uitpas truststore':
@@ -175,7 +230,7 @@ class profiles::uitpas::api (
     option  => '-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts',
     require => Profiles::Glassfish::Domain['uitpas'],
     notify  => Service['uitpas'],
-    *       => $default_attributes
+    *       => $default_attributes,
   }
 
   jvmoption { 'Domain uitpas timezone':
@@ -183,7 +238,7 @@ class profiles::uitpas::api (
     option  => '-Duser.timezone=CET',
     require => Profiles::Glassfish::Domain['uitpas'],
     notify  => Service['uitpas'],
-    *       => $default_attributes
+    *       => $default_attributes,
   }
 
   $settings.each |$name, $value| {
@@ -192,7 +247,7 @@ class profiles::uitpas::api (
       value   => $value,
       require => Profiles::Glassfish::Domain['uitpas'],
       notify  => Service['uitpas'],
-      *       => $default_attributes
+      *       => $default_attributes,
     }
   }
 
@@ -207,7 +262,7 @@ class profiles::uitpas::api (
       'running' => true,
       'stopped' => false
     },
-    require   => Profiles::Glassfish::Domain::Service_alias['uitpas']
+    require   => Profiles::Glassfish::Domain::Service_alias['uitpas'],
   }
 
   file { 'Domain uitpas mysql-connector-j':
@@ -215,7 +270,7 @@ class profiles::uitpas::api (
     path    => '/opt/payara/glassfish/lib/mysql-connector-j.jar',
     source  => '/usr/share/java/mysql-connector-j.jar',
     require => Package['mysql-connector-j'],
-    before  => Profiles::Glassfish::Domain['uitpas']
+    before  => Profiles::Glassfish::Domain['uitpas'],
   }
 
   # include ::profiles::uitpas::api::monitoring

--- a/manifests/uitpas/api.pp
+++ b/manifests/uitpas/api.pp
@@ -14,6 +14,9 @@ class profiles::uitpas::api (
   String                         $magda_soap_path,
   String                         $magda_soap_keystore,
   String                         $magda_soap_truststore,
+  String                         $magda_soap_cert_password,
+  String                         $magda_soap_key_password,
+  String                         $magda_soap_alias,
   Optional[String]               $newrelic_license_key = lookup('data::newrelic::license_key', Optional[String], 'first', undef),
   Integer                        $portbase             = 4800,
   Enum['running', 'stopped']     $service_status       = 'running',
@@ -40,45 +43,60 @@ class profiles::uitpas::api (
   $magda_soap_keystorepath = "${magda_soap_path}/${magda_soap_keystore}"
   $magda_soap_truststorepath  = "${magda_soap_path}/${magda_soap_truststore}"
 
-  file { "${magda_soap_path}":
+  file { $magda_soap_path:
     ensure => 'directory',
     owner  => 'glassfish',
     group  => 'glassfish',
     mode   => '0755',
   }
-  file { "${magda_sftp_path}":
+  file { $magda_sftp_path:
     ensure => 'directory',
     owner  => 'glassfish',
     group  => 'glassfish',
     mode   => '0755',
   }
-  file { "${magda_sftp_certpath}":
+  file { $magda_sftp_certpath:
     ensure  => 'file',
     content => $secrets["magda-sftp-crt"],
     owner   => 'glassfish',
     group   => 'glassfish',
     mode    => '0644',
+    require => File[$magda_sftp_path],
   }
-  file { "${magda_sftp_keypath}":
+  file { $magda_sftp_keypath:
     ensure  => 'file',
     content => $secrets["magda-sftp-key"],
     owner   => 'glassfish',
     group   => 'glassfish',
     mode    => '0600',
+    require => File[$magda_sftp_path],
   }
-  file { '/tmp/magda-soap-cert.crt':
+  file { "${magda_soap_path}/magda-soap-cert.crt":
     ensure  => 'file',
     content => $secrets["magda-soap-crt"],
     owner   => 'glassfish',
     group   => 'glassfish',
     mode    => '0644',
+    require => File[$magda_soap_path],
   }
-  file { '/tmp/magda-soap-key.pem':
+  file { "${magda_soap_path}/magda-soap-key.pem":
     ensure  => 'file',
     content => $secrets["magda-soap-key"],
     owner   => 'glassfish',
     group   => 'glassfish',
     mode    => '0600',
+    require => File[$magda_soap_path],
+  }
+  openssl::export::pkcs12 { $magda_soap_alias:
+    ensure    => 'present',
+    basedir   => $magda_soap_path,
+    pkey      => '/tmp/magda-soap-key.pem',
+    cert      => '/tmp/magda-soap-cert.crt',
+    in_pass   => $magda_soap_key_password,
+    out_pass  => $magda_soap_cert_password,
+    dynamic   => true,
+    resources => File["${magda_soap_path}/magda-soap-cert.crt","${magda_soap_path}/magda-soap-key.pem"],
+    require   => [File["${magda_soap_path}/magda-soap-cert.crt"], File["${magda_soap_path}/magda-soap-key.pem"]],
   }
 
   profiles::apache::vhost::reverse_proxy { "http://${servername}":

--- a/manifests/uitpas/api.pp
+++ b/manifests/uitpas/api.pp
@@ -97,6 +97,7 @@ class profiles::uitpas::api (
     dynamic   => true,
     resources => File["${magda_soap_path}/magda-soap-cert.crt","${magda_soap_path}/magda-soap-key.pem"],
     require   => [File["${magda_soap_path}/magda-soap-cert.crt"], File["${magda_soap_path}/magda-soap-key.pem"]],
+    notify    => Service['uitpas'],
   }
 
   profiles::apache::vhost::reverse_proxy { "http://${servername}":


### PR DESCRIPTION
This pull request introduces support for managing Magda SFTP and SOAP certificate/key files and keystores for the `uitpas` API Puppet manifest. It adds new parameters for Magda SFTP and SOAP paths and credentials, ensures the necessary files and directories are created with the correct permissions, and uses secrets from Vault. 

**Magda SFTP and SOAP integration:**

* Added parameters for Magda SFTP and SOAP paths, certificates, keys, keystore, truststore, and passwords to the `profiles::uitpas::api` class.
* Created directories and managed files for Magda SFTP and SOAP certificates/keys, sourcing their content from Vault secrets, with correct ownership and permissions.
* Added an `openssl::export::pkcs12` resource to generate a PKCS12 keystore for Magda SOAP, using the provided certificate and key, and ensuring it is kept up to date.

