### PR TITLE
Remove unneeded truststore

### DIFF
--- a/manifests/uitpas/api/magda.pp
+++ b/manifests/uitpas/api/magda.pp
@@ -55,14 +55,6 @@ class profiles::uitpas::api::magda (
     require => File[$magda_soap_path],
     notify  => Openssl::Export::Pkcs12[$magda_soap_alias],
   }
-  file { "${magda_soap_path}/${magda_soap_truststore}":
-    ensure => 'file',
-    source => '/etc/ssl/certs/java/cacerts',
-    owner  => 'glassfish',
-    group  => 'glassfish',
-    mode   => '0644',
-    require => File[$magda_soap_path],
-  }
   file { "${magda_soap_path}/magda-soap-key.pem":
     ensure  => 'file',
     content => base64('decode', $secrets["magda-soap-key"]),


### PR DESCRIPTION
### Added

-

### Changed

-

### Removed

- Truststore copy, due to pointing directly to cacerts

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
