### PR TITLE
Removes unnecessary parameter

### DIFF
--- a/manifests/uitid/reverse_proxy.pp
+++ b/manifests/uitid/reverse_proxy.pp
@@ -49,7 +49,6 @@ class profiles::uitid::reverse_proxy (
     compress      => true,
     delaycompress => true,
     missingok     => true,
-    notifempty    => true,
     create        => true,
     create_mode   => '0640',
     create_owner  => 'www-data',


### PR DESCRIPTION
Removes the `notifempty` parameter from the logrotate definition.

The parameter is redundant and does not affect the intended behavior.

### Added

-

### Changed

-

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
