### PR TITLE
Removes redundant logrotate configuration

### DIFF
--- a/manifests/uitid/reverse_proxy.pp
+++ b/manifests/uitid/reverse_proxy.pp
@@ -55,7 +55,6 @@ class profiles::uitid::reverse_proxy (
     create_group  => 'adm',
     sharedscripts => true,
     dateext       => true,
-    dateformat    => '-%Y%m%d.gz',
     prerotate     => [
       'if [ -d /etc/logrotate.d/httpd-prerotate ]; then',
       '  run-parts /etc/logrotate.d/httpd-prerotate;',


### PR DESCRIPTION
Removes the dateformat option from the logrotate configuration.

This option is not needed and can be removed to simplify the configuration.

### Added

-

### Changed

-

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
