### PR TITLE
Add profile for publiq mailpit

### DIFF
--- a/manifests/firewall/rules.pp
+++ b/manifests/firewall/rules.pp
@@ -78,6 +78,12 @@ class profiles::firewall::rules inherits ::profiles {
     action => 'accept'
   }
 
+  @firewall { '400 accept mailpit SMTP traffic':
+    proto  => 'tcp',
+    dport  => '1025',
+    action => 'accept'
+  }
+
   @firewall { '500 accept carbon traffic':
     proto  => 'tcp',
     dport  => '2003',

--- a/manifests/mailpit.pp
+++ b/manifests/mailpit.pp
@@ -1,10 +1,11 @@
 class profiles::mailpit (
   Stdlib::IP::Address::V4 $smtp_address = '127.0.0.1',
-  Integer                 $smtp_port    = 1025,
-  Stdlib::IP::Address::V4 $http_address = '127.0.0.1',
-  Integer                 $http_port    = 8025,
+  Stdlib::IP::Address::V4 $http_address = '127.0.0.1'
 
 ) inherits ::profiles {
+
+  $smtp_port = 1025
+  $http_port = 8025
 
   realize Group['mailpit']
   realize User['mailpit']

--- a/manifests/mailpit.pp
+++ b/manifests/mailpit.pp
@@ -7,9 +7,15 @@ class profiles::mailpit (
   $smtp_port = 1025
   $http_port = 8025
 
+  include profiles::firewall::rules
+
   realize Group['mailpit']
   realize User['mailpit']
   realize Apt::Source['publiq-tools']
+
+  if !($smtp_address == '127.0.0.1') {
+    realize Firewall['400 accept mailpit SMTP traffic']
+  }
 
   package { 'mailpit':
     ensure  => 'installed',

--- a/manifests/platform.pp
+++ b/manifests/platform.pp
@@ -44,12 +44,7 @@ class profiles::platform (
   }
 
   if $catch_mail {
-    class { 'profiles::mailpit':
-      smtp_address => '127.0.0.1',
-      smtp_port    => 1025,
-      http_address => '127.0.0.1',
-      http_port    => 8025
-    }
+    include profiles::mailpit
   }
 
   if $deployment {

--- a/manifests/publiq/mailpit.pp
+++ b/manifests/publiq/mailpit.pp
@@ -1,0 +1,18 @@
+class profiles::publiq::mailpit (
+  String                         $servername,
+  Variant[String, Array[String]] $serveraliases = []
+) inherits ::profiles {
+
+  include ::profiles::apache
+
+  class { 'profiles::mailpit':
+    smtp_address => '0.0.0.0'
+  }
+
+  profiles::apache::vhost::reverse_proxy { "http://${servername}":
+    aliases             => $serveraliases,
+    destination         => 'http://127.0.0.1:8025/',
+    auth_openid_connect => true,
+    require             => Class['profiles::mailpit']
+  }
+}

--- a/manifests/uitdatabank/entry_api.pp
+++ b/manifests/uitdatabank/entry_api.pp
@@ -88,12 +88,7 @@ class profiles::uitdatabank::entry_api (
   }
 
   if $catch_mail {
-    class { 'profiles::mailpit':
-      smtp_address => '127.0.0.1',
-      smtp_port    => 1025,
-      http_address => '127.0.0.1',
-      http_port    => 8025
-    }
+    include profiles::mailpit
   }
 
   profiles::apache::vhost::php_fpm { "http://${servername}":

--- a/spec/classes/firewall/rules_spec.rb
+++ b/spec/classes/firewall/rules_spec.rb
@@ -23,62 +23,68 @@ describe 'profiles::firewall::rules' do
         ) }
 
         it { is_expected.to contain_firewall('300 accept HTTP traffic').with(
-          'proto' => 'tcp',
-          'dport' => '80',
+          'proto'  => 'tcp',
+          'dport'  => '80',
           'action' => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('300 accept HTTPS traffic').with(
-          'proto' => 'tcp',
-          'dport' => '443',
+          'proto'  => 'tcp',
+          'dport'  => '443',
           'action' => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('300 accept SMTP traffic').with(
-          'proto' => 'tcp',
-          'dport' => '25',
+          'proto'  => 'tcp',
+          'dport'  => '25',
           'action' => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('300 accept puppetserver HTTPS traffic').with(
-          'proto' => 'tcp',
-          'dport' => '8140',
+          'proto'  => 'tcp',
+          'dport'  => '8140',
           'action' => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('300 accept puppetdb HTTPS traffic').with(
-          'proto' => 'tcp',
-          'dport' => '8081',
+          'proto'  => 'tcp',
+          'dport'  => '8081',
           'action' => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('400 accept redis traffic').with(
-          'proto' => 'tcp',
-          'dport' => '6379',
+          'proto'  => 'tcp',
+          'dport'  => '6379',
           'action' => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('400 accept meilisearch traffic').with(
-          'proto' => 'tcp',
-          'dport' => '7700',
+          'proto'  => 'tcp',
+          'dport'  => '7700',
           'action' => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('400 accept mysql traffic').with(
-          'proto' => 'tcp',
-          'dport' => '3306',
+          'proto'  => 'tcp',
+          'dport'  => '3306',
           'action' => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('400 accept vault traffic').with(
-          'proto' => 'tcp',
-          'dport' => '8200',
+          'proto'  => 'tcp',
+          'dport'  => '8200',
           'action' => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('400 accept mongodb traffic').with(
-          'proto' => 'tcp',
-          'dport' => '27017',
+          'proto'  => 'tcp',
+          'dport'  => '27017',
+          'action' => 'accept'
+        ) }
+
+        it { is_expected.to contain_firewall('400 accept mailpit SMTP traffic').with(
+          'proto'  => 'tcp',
+          'dport'  => '1025',
           'action' => 'accept'
         ) }
       end

--- a/spec/classes/mailpit_spec.rb
+++ b/spec/classes/mailpit_spec.rb
@@ -15,12 +15,14 @@ describe 'profiles::mailpit' do
 
           it { is_expected.to contain_class('profiles::mailpit').with(
             'smtp_address' => '127.0.0.1',
-            'http_address' => '127.0.0.1',
+            'http_address' => '127.0.0.1'
           ) }
 
           it { is_expected.to contain_group('mailpit') }
           it { is_expected.to contain_user('mailpit') }
           it { is_expected.to contain_apt__source('publiq-tools') }
+
+          it { is_expected.not_to contain_firewall('400 accept mailpit SMTP traffic') }
 
           it { is_expected.to contain_package('mailpit').with(
             'ensure' => 'installed'
@@ -65,6 +67,7 @@ describe 'profiles::mailpit' do
         context 'in the testing environment' do
           let(:environment) { 'testing' }
 
+          it { is_expected.to contain_firewall('400 accept mailpit SMTP traffic') }
           it { is_expected.to contain_file('mailpit-service-defaults').with_content(/^SMTP_ADDRESS=0\.0\.0\.0\nSMTP_PORT=1025\nHTTP_ADDRESS=127\.0\.1\.1\nHTTP_PORT=8025\nENVIRONMENT=testing$/) }
         end
       end

--- a/spec/classes/mailpit_spec.rb
+++ b/spec/classes/mailpit_spec.rb
@@ -15,9 +15,7 @@ describe 'profiles::mailpit' do
 
           it { is_expected.to contain_class('profiles::mailpit').with(
             'smtp_address' => '127.0.0.1',
-            'smtp_port'    => 1025,
             'http_address' => '127.0.0.1',
-            'http_port'    => 8025
           ) }
 
           it { is_expected.to contain_group('mailpit') }
@@ -58,18 +56,16 @@ describe 'profiles::mailpit' do
         end
       end
 
-      context 'with smtp_address => 127.0.1.1, smtp_port => 1234, http_address => 0.0.0.0 and http_port => 5678' do
+      context 'with smtp_address => 0.0.0.0 and http_address => 127.0.1.1' do
         let(:params) { {
-          'smtp_address' => '127.0.1.1',
-          'smtp_port'    => 1234,
-          'http_address' => '0.0.0.0',
-          'http_port'    => 5678
+          'smtp_address' => '0.0.0.0',
+          'http_address' => '127.0.1.1'
         } }
 
         context 'in the testing environment' do
           let(:environment) { 'testing' }
 
-          it { is_expected.to contain_file('mailpit-service-defaults').with_content(/^SMTP_ADDRESS=127\.0\.1\.1\nSMTP_PORT=1234\nHTTP_ADDRESS=0\.0\.0\.0\nHTTP_PORT=5678\nENVIRONMENT=testing$/) }
+          it { is_expected.to contain_file('mailpit-service-defaults').with_content(/^SMTP_ADDRESS=0\.0\.0\.0\nSMTP_PORT=1025\nHTTP_ADDRESS=127\.0\.1\.1\nHTTP_PORT=8025\nENVIRONMENT=testing$/) }
         end
       end
     end

--- a/spec/classes/platform_spec.rb
+++ b/spec/classes/platform_spec.rb
@@ -102,12 +102,7 @@ describe 'profiles::platform' do
 
           it { is_expected.not_to contain_class('profiles::platform::sling') }
 
-          it { is_expected.to contain_class('profiles::mailpit').with(
-            'smtp_address' => '127.0.0.1',
-            'smtp_port'    => 1025,
-            'http_address' => '127.0.0.1',
-            'http_port'    => 8025
-          ) }
+          it { is_expected.to contain_class('profiles::mailpit') }
 
           it { is_expected.to contain_profiles__apache__vhost__php_fpm('http://myplatform.example.com').with(
             'basedir'              => '/var/www/platform-api',

--- a/spec/classes/publiq/mailpit_spec.rb
+++ b/spec/classes/publiq/mailpit_spec.rb
@@ -1,0 +1,58 @@
+describe 'profiles::publiq::mailpit' do
+  include_examples 'operating system support'
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      context 'with hieradata' do
+        let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+        context 'with servername => mailpit.local' do
+          let(:params) { {
+            'servername' => 'mailpit.local'
+          } }
+
+          it { is_expected.to compile.with_all_deps }
+
+          it { is_expected.to contain_class('profiles::publiq::mailpit').with(
+            'servername'    => 'mailpit.local',
+            'serveraliases' => []
+          ) }
+
+          it { is_expected.to contain_class('profiles::apache') }
+          it { is_expected.to contain_class('profiles::mailpit').with(
+            'smtp_address' => '0.0.0.0'
+          ) }
+
+          it { is_expected.to contain_profiles__apache__vhost__reverse_proxy('http://mailpit.local').with(
+            'aliases'             => [],
+            'destination'         => 'http://127.0.0.1:8025/',
+            'auth_openid_connect' => true
+          ) }
+
+          it { is_expected.to contain_profiles__apache__vhost__reverse_proxy('http://mailpit.local').that_requires('Class[profiles::mailpit]') }
+        end
+
+        context 'with servername => mailpit.publiq.dev and serveraliases => mymailpit.publiq.dev' do
+          let(:params) { {
+            'servername'    => 'mailpit.publiq.dev',
+            'serveraliases' => 'mymailpit.publiq.dev'
+          } }
+
+          it { is_expected.to contain_profiles__apache__vhost__reverse_proxy('http://mailpit.publiq.dev').with(
+            'aliases'             => 'mymailpit.publiq.dev',
+            'destination'         => 'http://127.0.0.1:8025/',
+            'auth_openid_connect' => true
+          ) }
+        end
+      end
+
+      context 'without parameters' do
+        let(:params) { { } }
+
+        it { expect { catalogue }.to raise_error(Puppet::ParseError, /expects a value for parameter 'servername'/) }
+      end
+    end
+  end
+end

--- a/spec/classes/uitdatabank/entry_api_spec.rb
+++ b/spec/classes/uitdatabank/entry_api_spec.rb
@@ -255,12 +255,7 @@ describe 'profiles::uitdatabank::entry_api' do
               'bucket'        => 'test123'
             ) }
 
-            it { is_expected.to contain_class('profiles::mailpit').with(
-              'smtp_address' => '127.0.0.1',
-              'smtp_port'    => 1025,
-              'http_address' => '127.0.0.1',
-              'http_port'    => 8025
-            ) }
+            it { is_expected.to contain_class('profiles::mailpit') }
 
             it { is_expected.to contain_class('profiles::uitdatabank::entry_api::cron').with(
               'basedir'                           => '/var/www/udb3-backend',


### PR DESCRIPTION
- **Use include for mailpit profile invocation in UiTdatabank entry API and publiq platform**
- **Do not make mailpit SMTP and HTTP ports configurable**
- **Add firewall rule for mailpit SMTP traffic**
- **Add firewall rule if mailpit is not listening on 127.0.0.1**
- **Add profile for publiq mailpit**
