### PR TITLE
Fix warnings about Jenkins node labels

### DIFF
--- a/manifests/docker.pp
+++ b/manifests/docker.pp
@@ -54,7 +54,7 @@ class profiles::docker (
     require                     => Apt::Source['docker']
   }
 
-  profiles::jenkins::node_labels { 'docker':
+  @profiles::jenkins::node_labels { 'docker':
     content => 'docker'
   }
 

--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -20,7 +20,7 @@ class profiles::java (
         before  => Class['profiles::java::alternatives'],
       }
 
-      profiles::jenkins::node_labels { "openjdk-${version}":
+      @profiles::jenkins::node_labels { "openjdk-${version}":
         content => "java${version}"
       }
     } else {

--- a/manifests/jenkins/node.pp
+++ b/manifests/jenkins/node.pp
@@ -84,6 +84,8 @@ class profiles::jenkins::node (
     content => $os_labels
   }
 
+  Profiles::Jenkins::Node_labels <| |>
+
   concat { 'jenkins-swarm-client_node-labels':
     path           => '/etc/jenkins-swarm-client/node-labels.conf',
     owner          => 'jenkins',

--- a/manifests/nodejs.pp
+++ b/manifests/nodejs.pp
@@ -21,7 +21,7 @@ class profiles::nodejs (
     before                => Package['yarn']
   }
 
-  profiles::jenkins::node_labels { 'nodejs':
+  @profiles::jenkins::node_labels { 'nodejs':
     content => "nodejs${major_version}"
   }
 }

--- a/manifests/php.pp
+++ b/manifests/php.pp
@@ -133,7 +133,7 @@ class profiles::php (
     *            => $fpm_attributes
   }
 
-  profiles::jenkins::node_labels { 'php':
+  @profiles::jenkins::node_labels { 'php':
     content => "php${version}"
   }
 

--- a/manifests/terraform.pp
+++ b/manifests/terraform.pp
@@ -16,7 +16,7 @@ class profiles::terraform (
     require => Apt::Source['publiq-tools']
   }
 
-  profiles::jenkins::node_labels { 'terraform':
+  @profiles::jenkins::node_labels { 'terraform':
     content => 'terraform'
   }
 }

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -34,9 +34,7 @@ describe 'profiles::docker' do
           'docker_users'                => []
         ) }
 
-        it { is_expected.to contain_profiles__jenkins__node_labels('docker').with(
-          'content' => 'docker'
-        )}
+        it { is_expected.not_to contain_profiles__jenkins__node_labels('docker') }
 
         it { is_expected.to_not contain_profiles__lvm__mount('dockerdata') }
         it { is_expected.to_not contain_mount('/var/lib/docker') }
@@ -74,6 +72,14 @@ describe 'profiles::docker' do
 
         it { is_expected.to contain_apt__source('docker').that_comes_before('Class[docker]') }
         it { is_expected.to contain_file('/var/lib/docker').that_comes_before('Class[docker]') }
+
+        context 'with all virtual resources collected' do
+          let(:pre_condition) { 'Profiles::Jenkins::Node_labels <| |>' }
+
+          it { is_expected.to contain_profiles__jenkins__node_labels('docker').with(
+            'content' => 'docker'
+          ) }
+        end
       end
 
       context "with experimental => true, lvm => true, volume_group => dockervg, volume_size => 5G, ecr_registries => my.registry.com, ecr_users => ubuntu and schedule_prune => true" do

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -24,11 +24,17 @@ describe 'profiles::java' do
         ) }
 
         it { is_expected.to contain_package('openjdk-8-jre-headless') }
-        it { is_expected.to contain_profiles__jenkins__node_labels('openjdk-8').with(
-          'content' => 'java8'
-        ) }
+        it { is_expected.not_to contain_profiles__jenkins__node_labels('openjdk-8') }
 
         it { is_expected.to contain_package('openjdk-8-jre-headless').that_comes_before('Class[profiles::java::alternatives]') }
+
+        context 'with all virtual resources collected' do
+          let(:pre_condition) { 'Profiles::Jenkins::Node_labels <| |>' }
+
+          it { is_expected.to contain_profiles__jenkins__node_labels('openjdk-8').with(
+            'content' => 'java8'
+          ) }
+        end
       end
 
       context "with installed_versions => [17, 8], distribution => jdk and headless => false" do
@@ -50,11 +56,11 @@ describe 'profiles::java' do
         it { is_expected.to contain_package('openjdk-8-jdk') }
         it { is_expected.to contain_package('openjdk-17-jdk') }
 
-        it { is_expected.to contain_profiles__jenkins__node_labels('openjdk-17').with(
+        it { is_expected.not_to contain_profiles__jenkins__node_labels('openjdk-17').with(
           'content' => 'java17'
         ) }
 
-        it { is_expected.to contain_profiles__jenkins__node_labels('openjdk-8').with(
+        it { is_expected.not_to contain_profiles__jenkins__node_labels('openjdk-8').with(
           'content' => 'java8'
         ) }
 
@@ -66,6 +72,18 @@ describe 'profiles::java' do
 
         it { is_expected.to contain_package('openjdk-8-jdk').that_comes_before('Class[profiles::java::alternatives]') }
         it { is_expected.to contain_package('openjdk-17-jdk').that_comes_before('Class[profiles::java::alternatives]') }
+
+        context 'with all virtual resources collected' do
+          let(:pre_condition) { 'Profiles::Jenkins::Node_labels <| |>' }
+
+          it { is_expected.to contain_profiles__jenkins__node_labels('openjdk-17').with(
+            'content' => 'java17'
+          ) }
+
+          it { is_expected.to contain_profiles__jenkins__node_labels('openjdk-8').with(
+            'content' => 'java8'
+          ) }
+        end
       end
 
       context "with installed_versions => [8, 11] and default_version => 11" do
@@ -80,13 +98,8 @@ describe 'profiles::java' do
         it { is_expected.to contain_package('openjdk-8-jre') }
         it { is_expected.to contain_package('openjdk-11-jre') }
 
-        it { is_expected.to contain_profiles__jenkins__node_labels('openjdk-8').with(
-          'content' => 'java8'
-        ) }
-
-        it { is_expected.to contain_profiles__jenkins__node_labels('openjdk-11').with(
-          'content' => 'java11'
-        ) }
+        it { is_expected.not_to contain_profiles__jenkins__node_labels('openjdk-8') }
+        it { is_expected.not_to contain_profiles__jenkins__node_labels('openjdk-11') }
 
         it { is_expected.to contain_class('profiles::java::alternatives').with(
           'default_version' => 11,
@@ -96,6 +109,18 @@ describe 'profiles::java' do
 
         it { is_expected.to contain_package('openjdk-8-jre').that_comes_before('Class[profiles::java::alternatives]') }
         it { is_expected.to contain_package('openjdk-11-jre').that_comes_before('Class[profiles::java::alternatives]') }
+
+        context 'with all virtual resources collected' do
+          let(:pre_condition) { 'Profiles::Jenkins::Node_labels <| |>' }
+
+          it { is_expected.to contain_profiles__jenkins__node_labels('openjdk-8').with(
+            'content' => 'java8'
+          ) }
+
+          it { is_expected.to contain_profiles__jenkins__node_labels('openjdk-11').with(
+            'content' => 'java11'
+          ) }
+        end
       end
 
       context "with installed_versions => [13, 14] and default_version => 13" do

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -56,13 +56,9 @@ describe 'profiles::java' do
         it { is_expected.to contain_package('openjdk-8-jdk') }
         it { is_expected.to contain_package('openjdk-17-jdk') }
 
-        it { is_expected.not_to contain_profiles__jenkins__node_labels('openjdk-17').with(
-          'content' => 'java17'
-        ) }
+        it { is_expected.not_to contain_profiles__jenkins__node_labels('openjdk-17') }
 
-        it { is_expected.not_to contain_profiles__jenkins__node_labels('openjdk-8').with(
-          'content' => 'java8'
-        ) }
+        it { is_expected.not_to contain_profiles__jenkins__node_labels('openjdk-8') }
 
         it { is_expected.to contain_class('profiles::java::alternatives').with(
           'default_version' => 17,

--- a/spec/classes/jenkins/node_spec.rb
+++ b/spec/classes/jenkins/node_spec.rb
@@ -113,6 +113,29 @@ describe 'profiles::jenkins::node' do
           it { is_expected.to contain_service('jenkins-swarm-client').that_requires('User[jenkins]') }
           it { is_expected.to contain_service('jenkins-swarm-client').that_requires('Group[jenkins]') }
           it { is_expected.to contain_service('jenkins-swarm-client').that_subscribes_to('Class[profiles::java]') }
+
+          context 'with virtual resource profiles::jenkins::node_labels { terraform } defined' do
+            let(:pre_condition) { '@profiles::jenkins::node_labels { "terraform": content => "terraform" }' }
+
+            it { is_expected.to contain_profiles__jenkins__node_labels('terraform').with(
+              'content' => 'terraform'
+            ) }
+          end
+
+          context 'with virtual resources profiles::jenkins::node_labels { docker } and profiles::jenkins::node_labels { php } defined' do
+            let(:pre_condition) { [
+              '@profiles::jenkins::node_labels { "docker": content => "docker" }',
+              '@profiles::jenkins::node_labels { "php": content => "php8.2" }'
+            ] }
+
+            it { is_expected.to contain_profiles__jenkins__node_labels('docker').with(
+              'content' => 'docker'
+            ) }
+
+            it { is_expected.to contain_profiles__jenkins__node_labels('php').with(
+              'content' => 'php8.2'
+            ) }
+          end
         end
 
         context "with user => jane, password => roe, controller_url => 'http://localhost:5555/', lvm => true, volume_group => myvg, volume_size => 7G and executors => 4" do
@@ -180,7 +203,7 @@ describe 'profiles::jenkins::node' do
               ) }
             end
 
-            context "with labels => [bar, baz, oomph]" do
+            context "with labels => [bar, BAZ, oomph]" do
               let(:params) {
                 super().merge({
                   'labels' => ['bar', 'BAZ', 'oomph']

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -23,9 +23,7 @@ describe 'profiles::nodejs' do
           'nodejs_package_ensure' => 'present'
         ) }
 
-        it { is_expected.to contain_profiles__jenkins__node_labels('nodejs').with(
-          'content' => 'nodejs16'
-        )}
+        it { is_expected.not_to contain_profiles__jenkins__node_labels('nodejs') }
 
         it { is_expected.to contain_package('yarn').with(
           'ensure' => 'present'
@@ -34,6 +32,14 @@ describe 'profiles::nodejs' do
         it { is_expected.to contain_class('nodejs').that_requires('Apt::Source[nodejs-16]') }
         it { is_expected.to contain_package('yarn').that_requires('Apt::Source[publiq-tools]') }
         it { is_expected.to contain_package('yarn').that_requires('Class[nodejs]') }
+
+        context 'with all virtual resources collected' do
+          let(:pre_condition) { 'Profiles::Jenkins::Node_labels <| |>' }
+
+          it { is_expected.to contain_profiles__jenkins__node_labels('nodejs').with(
+            'content' => 'nodejs16'
+          ) }
+        end
       end
 
       context "with major_version => 18" do
@@ -46,11 +52,17 @@ describe 'profiles::nodejs' do
           'nodejs_package_ensure' => 'present'
         ) }
 
-        it { is_expected.to contain_profiles__jenkins__node_labels('nodejs').with(
-          'content' => 'nodejs18'
-        )}
+        it { is_expected.not_to contain_profiles__jenkins__node_labels('nodejs') }
 
         it { is_expected.to contain_class('nodejs').that_requires('Apt::Source[nodejs-18]') }
+
+        context 'with all virtual resources collected' do
+          let(:pre_condition) { 'Profiles::Jenkins::Node_labels <| |>' }
+
+          it { is_expected.to contain_profiles__jenkins__node_labels('nodejs').with(
+            'content' => 'nodejs18'
+          ) }
+        end
       end
 
       context "with version => 20.2.0-1nodesource1" do
@@ -62,11 +74,17 @@ describe 'profiles::nodejs' do
           'nodejs_package_ensure' => '20.2.0-1nodesource1'
         ) }
 
-        it { is_expected.to contain_profiles__jenkins__node_labels('nodejs').with(
-          'content' => 'nodejs20'
-        )}
+        it { is_expected.not_to contain_profiles__jenkins__node_labels('nodejs') }
 
         it { is_expected.to contain_class('nodejs').that_requires('Apt::Source[nodejs-20]') }
+
+        context 'with all virtual resources collected' do
+          let(:pre_condition) { 'Profiles::Jenkins::Node_labels <| |>' }
+
+          it { is_expected.to contain_profiles__jenkins__node_labels('nodejs').with(
+            'content' => 'nodejs20'
+          ) }
+        end
       end
 
       context "with version => 18.2.0-1nodesource1 and major_version => 20" do

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -89,9 +89,7 @@ describe 'profiles::php' do
               'reload_fpm_on_config_changes' => true
             ) }
 
-            it { is_expected.to contain_profiles__jenkins__node_labels('php').with(
-              'content' => 'php7.4'
-            )}
+            it { is_expected.not_to contain_profiles__jenkins__node_labels('php') }
 
             it { is_expected.to contain_file('php-fpm service').with(
               'ensure' => 'link',
@@ -126,6 +124,14 @@ describe 'profiles::php' do
             it { is_expected.to contain_class('php::globals').that_requires('Apt::Source[php]') }
             it { is_expected.to contain_class('php').that_requires('Class[php::globals]') }
             it { is_expected.to contain_file('php-fpm service').that_notifies('Systemd::Daemon_reload[php-fpm]') }
+
+            context 'with all virtual resources collected' do
+              let(:pre_condition) { 'Profiles::Jenkins::Node_labels <| |>' }
+
+              it { is_expected.to contain_profiles__jenkins__node_labels('php').with(
+                'content' => 'php7.4'
+              ) }
+            end
 
             context 'with fact phpversion => 7.3.2' do
               let(:facts) { super().merge(
@@ -210,9 +216,7 @@ describe 'profiles::php' do
             'fpm'                      => false
           ) }
 
-          it { is_expected.to contain_profiles__jenkins__node_labels('php').with(
-            'content' => 'php8.0'
-          )}
+          it { is_expected.not_to contain_profiles__jenkins__node_labels('php') }
 
           it { is_expected.not_to contain_file('php-fpm service') }
 
@@ -237,6 +241,14 @@ describe 'profiles::php' do
           it { is_expected.to contain_package('composer1').that_requires('Class[php]') }
           it { is_expected.to contain_package('composer2').that_requires('Class[php]') }
           it { is_expected.to contain_alternatives('composer').that_requires(['Package[composer1]', 'Package[composer2]']) }
+
+          context 'with all virtual resources collected' do
+            let(:pre_condition) { 'Profiles::Jenkins::Node_labels <| |>' }
+
+            it { is_expected.to contain_profiles__jenkins__node_labels('php').with(
+              'content' => 'php8.0'
+            ) }
+          end
 
           context 'with fact phpversion => 7.4.33' do
             let(:facts) { super().merge(
@@ -333,9 +345,7 @@ describe 'profiles::php' do
               'reload_fpm_on_config_changes' => false
             ) }
 
-            it { is_expected.to contain_profiles__jenkins__node_labels('php').with(
-              'content' => 'php8.2'
-            )}
+            it { is_expected.not_to contain_profiles__jenkins__node_labels('php') }
 
             it { is_expected.to contain_class('php::globals').with(
               'php_version' => '8.2',
@@ -354,6 +364,14 @@ describe 'profiles::php' do
               'app_name'    => 'bbb.example.com',
               'license_key' => 'my_license_key'
             ) }
+
+            context 'with all virtual resources collected' do
+              let(:pre_condition) { 'Profiles::Jenkins::Node_labels <| |>' }
+
+              it { is_expected.to contain_profiles__jenkins__node_labels('php').with(
+                'content' => 'php8.2'
+              ) }
+            end
 
             context 'with fact phpversion => 7.4.33' do
               let(:facts) { super().merge(

--- a/spec/classes/terraform_spec.rb
+++ b/spec/classes/terraform_spec.rb
@@ -26,12 +26,18 @@ describe 'profiles::terraform' do
           'ensure' => 'latest'
         ) }
 
-        it { is_expected.to contain_profiles__jenkins__node_labels('terraform').with(
-          'content' => 'terraform'
-        ) }
+        it { is_expected.not_to contain_profiles__jenkins__node_labels('terraform') }
 
         it { is_expected.to contain_apt__source('hashicorp').that_comes_before('Package[terraform]') }
         it { is_expected.to contain_apt__source('publiq-tools').that_comes_before('Package[terrafile]') }
+
+        context 'with all virtual resources collected' do
+          let(:pre_condition) { 'Profiles::Jenkins::Node_labels <| |>' }
+
+          it { is_expected.to contain_profiles__jenkins__node_labels('terraform').with(
+            'content' => 'terraform'
+          ) }
+        end
       end
 
       context "with version => 1.2.3 and terrafile_version => 4.5.6" do


### PR DESCRIPTION
The defined type profiles::jenkins::node_labels should only be declared when on
a Jenkins node, as it contains a concat::fragment which, on a node without a
corresponding concat resource, will issue a warning in that sense.

The solution is to define a virtual defined type profiles::jenkins::node_labels
on the tool class, so it gets defined but not declared, and collect all these
virtual defined type instances on the Jenkins nodes only.

- **Make profiles::jenkins::node_labels defined type a virtual resource**
- **Collect all profiles::jenkins::node_labels virtual resources on Jenkins nodes**
