### PR TITLE
Fix the broken docker.socket situation that prevents starting the docker service

### DIFF
--- a/manifests/docker.pp
+++ b/manifests/docker.pp
@@ -47,8 +47,6 @@ class profiles::docker (
 
   class { '::docker':
     use_upstream_package_source => false,
-    socket_override             => true,
-    socket_overrides_template   => 'profiles/docker/overrides.socket.conf.erb',
     docker_users                => [],
     extra_parameters            => [ "--experimental=${experimental}"],
     require                     => Apt::Source['docker']

--- a/manifests/docker.pp
+++ b/manifests/docker.pp
@@ -56,9 +56,10 @@ class profiles::docker (
     content => 'docker'
   }
 
-  class { profiles::docker::ecr_login:
+  class { 'profiles::docker::ecr_login':
     registries => $ecr_registries,
-    users      => $ecr_users
+    users      => $ecr_users,
+    require    => Class['::docker']
   }
 
   collectd::plugin::filter::rule { 'ignore_docker_mounts':

--- a/manifests/docker/ecr_login.pp
+++ b/manifests/docker/ecr_login.pp
@@ -3,9 +3,11 @@ class profiles::docker::ecr_login (
   Variant[String, Array[String]] $users      = []
 ) inherits ::profiles {
 
-  realize Package['amazon-ecr-credential-helper']
-
   $config_content = { "credHelpers" => [$registries].flatten.reduce({}) |Hash $all, String $registry| { $all + { $registry => 'ecr-login' } } }
+
+  package { 'amazon-ecr-credential-helper':
+    ensure => 'present'
+  }
 
   [$users].flatten.each |$user| {
     case $user {

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -169,10 +169,6 @@ inherits ::profiles {
     ensure  => 'present'
   }
 
-  @package { 'amazon-ecr-credential-helper':
-    ensure  => 'present'
-  }
-
   @package { 'awscli':
     ensure  => !!$versions['awscli'] ? { true => $versions['awscli'], default => 'present' },
     require => Apt::Source['publiq-tools']

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -70,6 +70,7 @@ describe 'profiles::docker' do
 
         it { is_expected.to contain_apt__source('docker').that_comes_before('Class[docker]') }
         it { is_expected.to contain_file('/var/lib/docker').that_comes_before('Class[docker]') }
+        it { is_expected.to contain_class('profiles::docker::ecr_login').that_requires('Class[docker]') }
 
         context 'with all virtual resources collected' do
           let(:pre_condition) { 'Profiles::Jenkins::Node_labels <| |>' }

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -28,8 +28,6 @@ describe 'profiles::docker' do
 
         it { is_expected.to contain_class('docker').with(
           'use_upstream_package_source' => false,
-          'socket_override'             => true,
-          'socket_overrides_template'   => 'profiles/docker/overrides.socket.conf.erb',
           'extra_parameters'            => [ '--experimental=false'],
           'docker_users'                => []
         ) }
@@ -120,8 +118,6 @@ describe 'profiles::docker' do
 
           it { is_expected.to contain_class('docker').with(
             'use_upstream_package_source' => false,
-            'socket_override'             => true,
-            'socket_overrides_template'   => 'profiles/docker/overrides.socket.conf.erb',
             'extra_parameters'            => [ '--experimental=true'],
             'docker_users'                => []
           ) }

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -137,10 +137,6 @@ describe 'profiles::packages' do
           'ensure' => 'present'
         ) }
 
-        it { is_expected.to contain_package('amazon-ecr-credential-helper').with(
-          'ensure' => 'present'
-        ) }
-
         it { is_expected.to contain_package('maven').with(
           'ensure' => 'present'
         ) }

--- a/templates/docker/overrides.socket.conf.erb
+++ b/templates/docker/overrides.socket.conf.erb
@@ -1,2 +1,0 @@
-[Unit]
-Before=docker.service


### PR DESCRIPTION
Install the amazon-ecr-credential-helper before the docker-ce package creates issues. The credential helper package pulls in containerd.io, docker.io which create a docker.socket and start the service. After that the docker-ce package gets installed, removes the containerd.io and docker.io packages and changes the docker.socket. This prevents the docker.socket from starting without a configuration reload, which in turn prevents the docker service from starting.

Switching the order of package installs should make this install/uninstall of containerd.io and docker.io not happen, with the subsequent problems with the docker.socket also not appearing.