### PR TITLE
Necessary changes for bootstrapping Jenkins agents on Ubuntu 24.04

### DIFF
--- a/manifests/jenkins/buildtools/extra.pp
+++ b/manifests/jenkins/buildtools/extra.pp
@@ -6,6 +6,7 @@ class profiles::jenkins::buildtools::extra inherits ::profiles {
 
   realize Package['argocd']
   realize Package['awscli']
+  realize Package['terrafile']
   realize Package['golang']
   realize Package['kubectl']
   realize Package['maven']

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -3,20 +3,6 @@ class profiles::packages (
 )
 inherits ::profiles {
 
-  @package { 'composer':
-    ensure => 'absent'
-  }
-
-  @package { 'composer1':
-    ensure  => 'present',
-    require => Apt::Source['publiq-tools']
-  }
-
-  @package { 'composer2':
-    ensure  => 'present',
-    require => Apt::Source['publiq-tools']
-  }
-
   @package { 'drush':
     ensure  => 'present',
     require => Apt::Source['publiq-tools']
@@ -50,6 +36,7 @@ inherits ::profiles {
   @package { 'yq':
     ensure => 'present'
   }
+
   @package { 'maven':
     ensure => 'present'
   }
@@ -177,6 +164,12 @@ inherits ::profiles {
   @package { 'terrafile':
     ensure  => !!$versions['terrafile'] ? { true => $versions['terrafile'], default => 'present' },
     require => Apt::Source['publiq-tools']
+  }
+
+  unless $facts['os']['release']['major'] == '20.04' {
+    @package { 'composer':
+      ensure  => !!$versions['composer'] ? { true => $versions['composer'], default => 'present' }
+    }
   }
 
   # Realize a list of 'default' packages on all nodes

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -174,6 +174,11 @@ inherits ::profiles {
     require => Apt::Source['publiq-tools']
   }
 
+  @package { 'terrafile':
+    ensure  => !!$versions['terrafile'] ? { true => $versions['terrafile'], default => 'present' },
+    require => Apt::Source['publiq-tools']
+  }
+
   # Realize a list of 'default' packages on all nodes
   realize Package['jq']
   realize Package['yq']

--- a/manifests/php.pp
+++ b/manifests/php.pp
@@ -2,7 +2,6 @@ class profiles::php (
   String                     $version                  = '7.4',
   Hash                       $extensions               = {},
   Hash                       $settings                 = {},
-  Integer[1, 2]              $composer_default_version = 2,
   Boolean                    $fpm                      = true,
   Enum['unix', 'tcp']        $fpm_socket_type          = 'unix',
   Enum['running', 'stopped'] $fpm_service_status       = 'running',
@@ -50,21 +49,30 @@ class profiles::php (
   }
 
   realize Apt::Source['php']
-  realize Apt::Source['publiq-tools']
 
-  realize Package['composer']
-  realize Package['composer1']
-  realize Package['composer2']
   realize Package['git']
 
-  Package['composer'] -> Package['composer1']
-  Package['composer'] -> Package['composer2']
-  Class['::php'] -> Package['composer1']
-  Class['::php'] -> Package['composer2']
+  case $facts['os']['release']['major'] {
+    '20.04': {
+      realize Apt::Source['publiq-tools']
 
-  alternatives { 'composer':
-    path    => "/usr/bin/composer${composer_default_version}",
-    require => [Package['composer1'], Package['composer2']]
+      package { 'composer1':
+        ensure  => 'absent'
+      }
+
+      package { 'composer2':
+        ensure  => 'present',
+        require => [Apt::Source['publiq-tools'], Class['::php']]
+      }
+
+      alternatives { 'composer':
+        path    => '/usr/bin/composer2',
+        require => Package['composer2']
+      }
+    }
+    default: {
+      realize Package['composer']
+    }
   }
 
   if $fpm {

--- a/manifests/terraform.pp
+++ b/manifests/terraform.pp
@@ -1,19 +1,12 @@
 class profiles::terraform (
-  String $version           = 'latest',
-  String $terrafile_version = 'latest'
+  String $version = 'latest'
 ) inherits ::profiles {
 
   realize Apt::Source['hashicorp']
-  realize Apt::Source['publiq-tools']
 
   package { 'terraform':
     ensure  => $version,
     require => Apt::Source['hashicorp']
-  }
-
-  package { 'terrafile':
-    ensure  => $terrafile_version,
-    require => Apt::Source['publiq-tools']
   }
 
   @profiles::jenkins::node_labels { 'terraform':

--- a/spec/classes/jenkins/buildtools/extra_spec.rb
+++ b/spec/classes/jenkins/buildtools/extra_spec.rb
@@ -20,12 +20,14 @@ describe 'profiles::jenkins::buildtools::extra' do
         let(:hiera_config) { 'spec/support/hiera/common.yaml' }
 
         it { is_expected.to contain_package('awscli').with({ 'ensure' => 'latest' }) }
+        it { is_expected.to contain_package('terrafile').with({ 'ensure' => 'latest' }) }
       end
 
       context 'without hieradata' do
         let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
 
         it { is_expected.to contain_package('awscli').with({ 'ensure' => 'present' }) }
+        it { is_expected.to contain_package('terrafile').with({ 'ensure' => 'present' }) }
       end
     end
   end

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -147,12 +147,20 @@ describe 'profiles::packages' do
           it { is_expected.to contain_package('awscli').with(
             'ensure' => 'latest'
           ) }
+
+          it { is_expected.to contain_package('terrafile').with(
+            'ensure' => 'latest'
+          ) }
         end
 
         context 'without hieradata' do
           let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
 
           it { is_expected.to contain_package('awscli').with(
+            'ensure' => 'present'
+          ) }
+
+          it { is_expected.to contain_package('terrafile').with(
             'ensure' => 'present'
           ) }
         end
@@ -173,6 +181,7 @@ describe 'profiles::packages' do
         it { is_expected.to contain_package('rubygem-angular-config').that_requires('Apt::Source[publiq-tools]') }
         it { is_expected.to contain_package('prince').that_requires('Apt::Source[publiq-tools]') }
         it { is_expected.to contain_package('awscli').that_requires('Apt::Source[publiq-tools]') }
+        it { is_expected.to contain_package('terrafile').that_requires('Apt::Source[publiq-tools]') }
       end
 
       context "without package virtual resources realized" do

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -13,18 +13,6 @@ describe 'profiles::packages' do
           'Apt::Source <| |>'
         ] }
 
-        it { is_expected.to contain_package('composer').with(
-          'ensure' => 'absent'
-        ) }
-
-        it { is_expected.to contain_package('composer1').with(
-          'ensure' => 'present'
-        ) }
-
-        it { is_expected.to contain_package('composer2').with(
-          'ensure' => 'present'
-        ) }
-
         it { is_expected.to contain_package('git').with(
           'ensure' => 'present'
         ) }
@@ -165,8 +153,6 @@ describe 'profiles::packages' do
           ) }
         end
 
-        it { is_expected.to contain_package('composer1').that_requires('Apt::Source[publiq-tools]') }
-        it { is_expected.to contain_package('composer2').that_requires('Apt::Source[publiq-tools]') }
         it { is_expected.to contain_package('drush').that_requires('Apt::Source[publiq-tools]') }
         it { is_expected.to contain_package('ca-certificates-publiq').that_requires('Apt::Source[publiq-tools]') }
         it { is_expected.to contain_package('gcsfuse').that_requires('Apt::Source[publiq-tools]') }

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -20,7 +20,6 @@ describe 'profiles::php' do
               'version'                  => '7.4',
               'extensions'               => {},
               'settings'                 => {},
-              'composer_default_version' => 2,
               'fpm'                      => true,
               'fpm_socket_type'          => 'tcp',
               'fpm_service_status'       => 'running',
@@ -32,7 +31,6 @@ describe 'profiles::php' do
             ) }
 
             it { is_expected.to contain_apt__source('php') }
-            it { is_expected.to contain_apt__source('publiq-tools') }
 
             it { is_expected.to contain_class('php::globals').with(
               'php_version' => '7.4',
@@ -99,21 +97,29 @@ describe 'profiles::php' do
 
             it { is_expected.to contain_systemd__daemon_reload('php-fpm') }
 
-            it { is_expected.to contain_package('composer').with(
-              'ensure' => 'absent'
-            ) }
+            case facts[:os]['release']['major']
+            when '20.04'
+              it { is_expected.to contain_apt__source('publiq-tools') }
 
-            it { is_expected.to contain_package('composer1').with(
-              'ensure' => 'present'
-            ) }
+              it { is_expected.to contain_package('composer1').with(
+                'ensure' => 'absent'
+              ) }
 
-            it { is_expected.to contain_package('composer2').with(
-              'ensure' => 'present'
-            ) }
+              it { is_expected.to contain_package('composer2').with(
+                'ensure' => 'present'
+              ) }
 
-            it { is_expected.to contain_alternatives('composer').with(
-              'path' => '/usr/bin/composer2'
-            ) }
+              it { is_expected.to contain_alternatives('composer').with(
+                'path' => '/usr/bin/composer2'
+              ) }
+
+              it { is_expected.to contain_package('composer2').that_requires('Apt::Source[publiq-tools]') }
+              it { is_expected.to contain_alternatives('composer').that_requires('Package[composer2]') }
+            else
+              it { is_expected.to contain_package('composer').with(
+                'ensure' => 'present'
+              ) }
+            end
 
             it { is_expected.to contain_package('git').with(
               'ensure' => 'present'
@@ -155,7 +161,6 @@ describe 'profiles::php' do
               'version'                  => '7.4',
               'extensions'               => {},
               'settings'                 => {},
-              'composer_default_version' => 2,
               'fpm'                      => true,
               'fpm_socket_type'          => 'unix',
               'fpm_service_status'       => 'running',
@@ -167,20 +172,19 @@ describe 'profiles::php' do
           end
         end
 
-        context 'with version => 8.0, extensions => { mbstring => {}, mysql => { so_name => mysqlnd }, mongodb => {} }, settings => { PHP/upload_max_filesize => 22M, PHP/post_max_size => 24M }, fpm => false and composer_default_version => 1' do
+        context 'with version => 8.0, extensions => { mbstring => {}, mysql => { so_name => mysqlnd }, mongodb => {} }, settings => { PHP/upload_max_filesize => 22M, PHP/post_max_size => 24M } and fpm => false' do
           let(:params) { {
-            'version'                  => '8.0',
-            'extensions'               => {
-                                            'mbstring' => {},
-                                            'mysql'    => { 'so_name' => 'mysqlnd' },
-                                            'mongodb'  => {}
-                                          },
-            'settings'                 => {
-                                            'PHP/upload_max_filesize' => '22M',
-                                            'PHP/post_max_size'       => '24M'
-                                          },
-            'fpm'                      => false,
-            'composer_default_version' => 1
+            'version'    => '8.0',
+            'extensions' => {
+                              'mbstring' => {},
+                              'mysql'    => { 'so_name' => 'mysqlnd' },
+                              'mongodb'  => {}
+                            },
+            'settings'   => {
+                              'PHP/upload_max_filesize' => '22M',
+                              'PHP/post_max_size'       => '24M'
+                            },
+            'fpm'        => false,
           } }
 
           it { is_expected.to contain_class('php::globals').with(
@@ -222,25 +226,7 @@ describe 'profiles::php' do
 
           it { is_expected.not_to contain_systemd__daemon_reload('php-fpm') }
 
-          it { is_expected.to contain_apt__source('publiq-tools') }
-
-          it { is_expected.to contain_package('composer1').with(
-            'ensure' => 'present'
-          ) }
-
-          it { is_expected.to contain_package('composer2').with(
-            'ensure' => 'present'
-          ) }
-
-          it { is_expected.to contain_alternatives('composer').with(
-            'path' => '/usr/bin/composer1'
-          ) }
-
           it { is_expected.not_to contain_class('profiles::newrelic::php') }
-
-          it { is_expected.to contain_package('composer1').that_requires('Class[php]') }
-          it { is_expected.to contain_package('composer2').that_requires('Class[php]') }
-          it { is_expected.to contain_alternatives('composer').that_requires(['Package[composer1]', 'Package[composer2]']) }
 
           context 'with all virtual resources collected' do
             let(:pre_condition) { 'Profiles::Jenkins::Node_labels <| |>' }
@@ -263,18 +249,17 @@ describe 'profiles::php' do
       context 'on node bbb.example.com' do
         let(:node) { 'bbb.example.com' }
 
-        context 'with version => 8.2, composer_default_version => 1, newrelic => true, fpm_socket_type => unix, fpm_restart_on_change => true, fpm_settings => { pm_max_children => 100, pm_max_requests => 5000 } and fpm_service_status => stopped' do
+        context 'with version => 8.2, newrelic => true, fpm_socket_type => unix, fpm_restart_on_change => true, fpm_settings => { pm_max_children => 100, pm_max_requests => 5000 } and fpm_service_status => stopped' do
           let(:params) { {
-            'version'                  => '8.2',
-            'composer_default_version' => 1,
-            'fpm_socket_type'          => 'unix',
-            'fpm_service_status'       => 'stopped',
-            'fpm_restart_on_change'    => true,
-            'fpm_settings'             => {
-                                            'pm_max_children' => 100,
-                                            'pm_max_requests' => 5000
-                                          },
-            'newrelic'                 => true
+            'version'               => '8.2',
+            'fpm_socket_type'       => 'unix',
+            'fpm_service_status'    => 'stopped',
+            'fpm_restart_on_change' => true,
+            'fpm_settings'          => {
+                                         'pm_max_children' => 100,
+                                         'pm_max_requests' => 5000
+                                       },
+            'newrelic'              => true
           } }
 
           context 'with hieradata' do
@@ -282,20 +267,6 @@ describe 'profiles::php' do
 
             it { is_expected.to contain_class('profiles::php').with(
               'newrelic_app_name' => 'bbb.example.com'
-            ) }
-
-            it { is_expected.to contain_apt__source('publiq-tools') }
-
-            it { is_expected.to contain_package('composer1').with(
-              'ensure' => 'present'
-            ) }
-
-            it { is_expected.to contain_package('composer2').with(
-              'ensure' => 'present'
-            ) }
-
-            it { is_expected.to contain_alternatives('composer').with(
-              'path' => '/usr/bin/composer1'
             ) }
 
             it { is_expected.to contain_class('php').with(

--- a/spec/classes/terraform_spec.rb
+++ b/spec/classes/terraform_spec.rb
@@ -11,25 +11,18 @@ describe 'profiles::terraform' do
         it { is_expected.to compile.with_all_deps }
 
         it { is_expected.to contain_class('profiles::terraform').with(
-          'version'           => 'latest',
-          'terrafile_version' => 'latest'
+          'version' => 'latest'
         ) }
 
-        it { is_expected.to contain_apt__source('publiq-tools') }
         it { is_expected.to contain_apt__source('hashicorp') }
 
         it { is_expected.to contain_package('terraform').with(
           'ensure' => 'latest'
         ) }
 
-        it { is_expected.to contain_package('terrafile').with(
-          'ensure' => 'latest'
-        ) }
-
         it { is_expected.not_to contain_profiles__jenkins__node_labels('terraform') }
 
         it { is_expected.to contain_apt__source('hashicorp').that_comes_before('Package[terraform]') }
-        it { is_expected.to contain_apt__source('publiq-tools').that_comes_before('Package[terrafile]') }
 
         context 'with all virtual resources collected' do
           let(:pre_condition) { 'Profiles::Jenkins::Node_labels <| |>' }
@@ -40,18 +33,13 @@ describe 'profiles::terraform' do
         end
       end
 
-      context "with version => 1.2.3 and terrafile_version => 4.5.6" do
+      context "with version => 1.2.3" do
         let(:params) { {
-          'version'           => '1.2.3',
-          'terrafile_version' => '4.5.6'
+          'version' => '1.2.3'
         } }
 
         it { is_expected.to contain_package('terraform').with(
           'ensure' => '1.2.3'
-        ) }
-
-        it { is_expected.to contain_package('terrafile').with(
-          'ensure' => '4.5.6'
         ) }
       end
     end

--- a/spec/support/hiera/data/common.yaml
+++ b/spec/support/hiera/data/common.yaml
@@ -13,6 +13,7 @@ data::mysql::2ndline_ro::password: 'my_2ndline_ro_password'
 
 profiles::packages::versions:
   awscli: 'latest'
+  terrafile: 'latest'
 
 profiles::jenkins::controller::admin_password: 'bar'
 profiles::jenkins::controller::url: 'https://foobar.com/'


### PR DESCRIPTION
Two changes are needed for bootstrapping Jenkins agents on a new OS release:
* `terrafile` needs to be moved out of the Terraform profile (which is added in
  the Jenkins agent role and provided through the extra buildtools
* `composer` is part of the official Ubuntu repositories as of 24.04. The PHP
  profiles is updated to reflect this. Also, composer2 is installed everywhere
  on Ubuntu 20.04, so the configuration is not needed anymore.


- **Move terrafile package out of terraform profile to allow Jenkins agent bootstrap to succeed**
- **Remove terrafile from Terraform profile**
- **Ubuntu 24.04 has composer in the default repositories**
