### PR TITLE
Switch from puppet to openvox gem and remove puppetlabs_spec_helper dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -135,6 +135,12 @@ fixtures:
     rsyslog:
       repo: 'puppet/rsyslog'
       ref: '7.3.0'
+    rabbitmq:
+      repo: 'puppet/rabbitmq'
+      ref: '13.4.0'
+    archive:
+      repo: 'puppet/archive'
+      ref: '6.1.2'
     debconf:
       repo: 'stm/debconf'
       ref: '6.2.0'
@@ -142,9 +148,6 @@ fixtures:
     filebeat:
       repo: 'https://github.com/cultuurnet/puppet-filebeat.git'
       ref: '598539b'
-    rabbitmq:
-      repo: 'https://github.com/cultuurnet/puppetlabs-rabbitmq.git'
-      ref: 'cdcb352'
     borgbackup:
       repo: 'https://github.com/cultuurnet/puppet-borgbackup.git'
       ref: '0c92c9b'

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -161,5 +161,5 @@ fixtures:
       repo: 'https://github.com/cultuurnet/puppetlabs-mysql.git'
       ref: '844aa07'
   symlinks:
-    appconfig: "#{source_dir}/spec/support/appconfig"
-    profiles: "#{source_dir}"
+    appconfig: ${PWD}/spec/support/appconfig
+    profiles: ${PWD}

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -153,7 +153,7 @@ fixtures:
       ref: '0c92c9b'
     glassfish:
       repo: 'https://github.com/cultuurnet/fatmcgav-glassfish.git'
-      ref: 'c9ec792'
+      ref: 'f91d0b6f'
     aptly:
       repo: 'https://github.com/cultuurnet/puppet-aptly.git'
       ref: '2d5031b'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,4 @@ jobs:
         run: bundle exec rake syntax
 
       - name: Run unit tests
-        run: bundle exec rake spec
+        run: bundle exec rake spec MAX_FIXTURE_THREAD_COUNT=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     if: ${{ ! github.event.pull_request.merged }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
@@ -17,7 +17,7 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.0
+          ruby-version: 3.2.3
 
       - name: Install dependencies
         run: bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -7,14 +7,15 @@ group :development, :test do
   gem 'guard', :require => false
   gem 'guard-rspec', :require => false
   gem 'metadata-json-lint', :require => false
-  gem 'puppetlabs_spec_helper', '< 3.0.0', :require => false
+  gem 'puppet-syntax', '6.0.0', :require => false
+  gem 'puppet_fixtures', :require => false
   gem 'puppet-lint', :require => false
   gem 'rake', :require => false
   gem 'rspec-puppet', :require => false
-  gem 'rspec-puppet-facts', :require => false
+  gem 'rspec-puppet-facts', '5.4.0', :require => false
   gem 'semantic_puppet', :require => false
-  gem 'facter', '4.3.1', :require => false
-  gem 'puppet', '7.24.0', :require => false
+  gem 'facter', '4.10.0', :require => false
+  gem 'openvox', '7.37.2', :require => false
 end
 
 # vim:ft=ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,12 +8,11 @@ GEM
     date (3.4.1)
     deep_merge (1.2.2)
     diff-lcs (1.5.0)
-    facter (4.3.1)
+    facter (4.10.0)
       hocon (~> 1.3)
-      thor (>= 1.0.1, < 2.0)
-    facterdb (1.22.0)
-      facter (< 5.0.0)
-      jgrep
+      thor (>= 1.0.1, < 1.3)
+    facterdb (3.10.0)
+      jgrep (~> 1.5, >= 1.5.4)
     fast_gettext (2.3.0)
     ffi (1.16.3)
     formatador (1.1.0)
@@ -41,13 +40,13 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     locale (2.1.3)
+    logger (1.7.0)
     lumberjack (1.2.10)
     metadata-json-lint (4.0.0)
       json-schema (>= 2.8, < 5.0)
       semantic_puppet (~> 1.0)
       spdx-licenses (~> 1.0)
     method_source (1.0.0)
-    mocha (1.16.1)
     multi_json (1.15.0)
     nenv (0.3.0)
     net-ftp (0.3.8)
@@ -58,13 +57,8 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    pathspec (1.0.0)
-    pry (0.14.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    public_suffix (5.0.4)
-    puppet (7.24.0)
-      concurrent-ruby (~> 1.0, < 1.2.0)
+    openvox (7.37.2)
+      concurrent-ruby (~> 1.0)
       deep_merge (~> 1.0)
       facter (> 2.0.1, < 5)
       fast_gettext (>= 1.1, < 3)
@@ -74,18 +68,19 @@ GEM
       puppet-resource_api (~> 1.5)
       scanf (~> 1.0)
       semantic_puppet (~> 1.0)
-    puppet-lint (2.5.2)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    public_suffix (5.0.4)
+    puppet-lint (4.3.0)
     puppet-resource_api (1.9.0)
       hocon (>= 1.0)
-    puppet-syntax (3.3.0)
-      puppet (>= 5)
-      rake
-    puppetlabs_spec_helper (2.16.0)
-      mocha (~> 1.0)
-      pathspec (>= 0.2.1, < 1.1.0)
-      puppet-lint (~> 2.0)
-      puppet-syntax (>= 2.0, < 4)
-      rspec-puppet (~> 2.0)
+    puppet-syntax (6.0.0)
+      openvox (>= 7, < 9)
+      rake (~> 13.1)
+    puppet_fixtures (2.2.1)
+      logger (< 2)
+      rake (~> 13.0)
     rake (13.1.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -102,18 +97,18 @@ GEM
     rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-puppet (2.12.0)
-      rspec
-    rspec-puppet-facts (2.0.5)
-      facter
-      facterdb (>= 0.5.0)
-      puppet
+    rspec-puppet (4.0.2)
+      rspec (~> 3.0)
+    rspec-puppet-facts (5.4.0)
+      deep_merge (~> 1.2)
+      facter (< 5)
+      facterdb (~> 3.1)
     rspec-support (3.12.1)
     scanf (1.0.0)
     semantic_puppet (1.1.0)
     shellany (0.0.1)
     spdx-licenses (1.3.0)
-    thor (1.3.0)
+    thor (1.2.2)
     time (0.4.1)
       date
     timeout (0.4.3)
@@ -122,17 +117,21 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  facter (= 4.3.1)
+  facter (= 4.10.0)
   guard
   guard-rspec
   json
   metadata-json-lint
   net-ftp
-  puppet (= 7.24.0)
+  openvox (= 7.37.2)
   puppet-lint
-  puppetlabs_spec_helper (< 3.0.0)
+  puppet-syntax (= 6.0.0)
+  puppet_fixtures
   rake
   rspec-puppet
-  rspec-puppet-facts
+  rspec-puppet-facts (= 5.4.0)
   scanf
   semantic_puppet
+
+BUNDLED WITH
+   2.4.20

--- a/Rakefile
+++ b/Rakefile
@@ -16,11 +16,17 @@ task :default do
   system("rake -T")
 end
 
-RSpec::Core::RakeTask.new(:spec) do |task|
+RSpec::Core::RakeTask.new(:'spec:standalone') do |task|
   task.pattern = 'spec/{aliases,classes,defines,functions,hosts,integration,plans,tasks,type_aliases,types,unit}/**/*_spec.rb'
 end
 
-desc "Run syntax, lint, and spec tests."
+desc "Install fixtures and run spec tests."
+task :spec => [
+  :'fixtures:prep',
+  :'spec:standalone'
+]
+
+desc "Run syntax, lint, and spec tasks."
 task :test => [
   :syntax,
   :lint,

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,31 @@
 require 'puppet'
-require 'puppetlabs_spec_helper/rake_tasks'
+require 'rspec/core/rake_task'
+require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet-lint/tasks/puppet-lint'
+require 'puppet_fixtures/tasks'
+
+PuppetSyntax.hieradata_paths = ["spec/support/hiera/data/*.yaml"]
+PuppetSyntax.exclude_paths = ['spec/fixtures/**/*', 'vendor/**/*', 'spec/support/hiera/data/vault.yaml']
 
 PuppetLint.configuration.send('disable_80chars')
 PuppetLint.configuration.send('disable_puppet_url_without_modules')
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+
+desc "Default task prints the available targets."
+task :default do
+  system("rake -T")
+end
+
+RSpec::Core::RakeTask.new(:spec) do |task|
+  task.pattern = 'spec/{aliases,classes,defines,functions,hosts,integration,plans,tasks,type_aliases,types,unit}/**/*_spec.rb'
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec
+]
 
 desc "Validate manifests, templates, and ruby files"
 task :validate do
@@ -17,16 +38,4 @@ task :validate do
   Dir['templates/**/*.erb'].each do |template|
     sh "erb -P -x -T '-' #{template} | ruby -c"
   end
-end
-
-desc "Run syntax, lint, and spec tests."
-task :test => [
-  :syntax,
-  :spec,
-  :lint
-]
-
-desc "Default task prints the available targets."
-task :default do
-  system("rake -T")
 end

--- a/manifests/puppet/puppetboard.pp
+++ b/manifests/puppet/puppetboard.pp
@@ -34,6 +34,7 @@ class profiles::puppet::puppetboard (
     puppetdb_ssl_verify => "${basedir}/ssl/ca.pem",
     puppetdb_key        => "${basedir}/ssl/private.pem",
     puppetdb_cert       => "${basedir}/ssl/public.pem",
+    python_version      => $facts['python3_release'],
     enable_catalog      => false,
     enable_query        => true,
     default_environment => 'production',

--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -13,9 +13,6 @@ class profiles::python (
   }
 
   @profiles::jenkins::node_labels { 'python':
-    content => $facts['os']['distro']['codename'] ? {
-                 'focal' => 'python3.8',
-                 'noble' => 'python3.12'
-               }
+    content => "python${facts['python3_release']}"
   }
 }

--- a/manifests/rabbitmq.pp
+++ b/manifests/rabbitmq.pp
@@ -15,7 +15,7 @@ class profiles::rabbitmq (
   }
 
   class { '::rabbitmq':
-    manage_repos      => false,
+    repos_ensure      => false,
     package_ensure    => $version,
     delete_guest_user => true,
     require           => Package['erlang-nox']

--- a/manifests/ssh.pp
+++ b/manifests/ssh.pp
@@ -36,7 +36,6 @@ class profiles::ssh(
 
   if $settings::storeconfigs {
     @@sshkey { "${facts['networking']['hostname']}@ssh-rsa":
-      type         => 'ssh-rsa',
       key          => $facts['ssh']['rsa']['key'],
       host_aliases => [$facts['networking']['ip'], $facts['networking']['fqdn']],
       provider     => 'parsed'

--- a/manifests/uitpas/segmentation_dbase.pp
+++ b/manifests/uitpas/segmentation_dbase.pp
@@ -1,7 +1,7 @@
 class profiles::uitpas::segmentation_dbase (
   String $database_name = 'uitpas_seg_prod_copy',
   String $ro_user       = '2ndline_ro',
-  String $ro_password   = lookup('data::mysql::2ndline_ro::password', Optional[String], 'first', undef),
+  String $ro_password   = lookup('data::mysql::secondline_ro::password', Optional[String], 'first', undef),
   String $rw_password   = undef,
   String $rw_user       = undef
 ) inherits ::profiles {

--- a/spec/classes/apt/repositories_spec.rb
+++ b/spec/classes/apt/repositories_spec.rb
@@ -106,10 +106,10 @@ describe 'profiles::apt::repositories' do
           context 'in the acceptance environment' do
             let(:environment) { 'acceptance' }
 
-            include_examples 'apt repositories', 'noble', { :location => 'https://apt-mirror.publiq.be/noble-amd64-testing', :repos => 'main', :release => 'noble' }
-            include_examples 'apt repositories', 'noble-updates', { :location => 'https://apt-mirror.publiq.be/noble-updates-amd64-testing', :repos => 'main', :release => 'noble-updates' }
-            include_examples 'apt repositories', 'noble-security', { :location => 'https://apt-mirror.publiq.be/noble-security-amd64-testing', :repos => 'main', :release => 'noble-security' }
-            include_examples 'apt repositories', 'noble-backports', { :location => 'https://apt-mirror.publiq.be/noble-backports-amd64-testing', :repos => 'main', :release => 'noble-backports' }
+            include_examples 'apt repositories', 'noble', { :location => 'https://apt-mirror.publiq.be/noble-amd64-acceptance', :repos => 'main', :release => 'noble' }
+            include_examples 'apt repositories', 'noble-updates', { :location => 'https://apt-mirror.publiq.be/noble-updates-amd64-acceptance', :repos => 'main', :release => 'noble' }
+            include_examples 'apt repositories', 'noble-security', { :location => 'https://apt-mirror.publiq.be/noble-security-amd64-acceptance', :repos => 'main', :release => 'noble' }
+            include_examples 'apt repositories', 'noble-backports', { :location => 'https://apt-mirror.publiq.be/noble-backports-amd64-acceptance', :repos => 'main', :release => 'noble' }
 
             include_examples 'apt repositories', 'php', { :location => 'https://apt-mirror.publiq.be/php-noble-acceptance', :repos => 'main', :release => 'noble' }
           end

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -3,7 +3,7 @@ describe 'profiles::postfix' do
 
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      let(:facts) { facts }
+      let(:facts) { facts.merge( { 'osfamily' => facts[:os]['family'], 'operatingsystem' => facts[:os]['name'], 'operatingsystemrelease' => facts[:os]['release']['full'] }) }
 
       context "on host with ipaddress 1.2.3.4" do
         let(:facts) {

--- a/spec/classes/puppet/puppetboard_spec.rb
+++ b/spec/classes/puppet/puppetboard_spec.rb
@@ -8,125 +8,130 @@ describe 'profiles::puppet::puppetboard' do
       context 'on node node1.example.com' do
         let(:node) { 'node1.example.com' }
 
-        context 'with servername => puppetboard.example.com' do
-          let(:params) { {
-            'servername' => 'puppetboard.example.com'
-          } }
+        context 'with Python 3.8 available' do
+          let(:facts) { facts.merge({ 'python3_release' => '3.8' }) }
 
-          it { is_expected.to compile.with_all_deps }
-
-          it { is_expected.to contain_class('profiles::apache') }
-
-          it { is_expected.to contain_class('profiles::puppet::puppetboard').with(
-            'servername'      => 'puppetboard.example.com',
-            'serveraliases'   => [],
-            'service_address' => '127.0.0.1',
-            'service_port'    => 6000,
-            'service_status'  => 'running',
-            'auth'            => false
-          ) }
-
-          it { is_expected.to contain_apt__source('publiq-tools') }
-          it { is_expected.to contain_group('www-data') }
-          it { is_expected.to contain_user('www-data') }
-
-          it { is_expected.to contain_service('puppetboard').with(
-            'ensure'    => 'running',
-            'hasstatus' => true,
-            'enable'    => true
-          ) }
-
-          it { is_expected.to contain_class('puppetboard').with(
-            'install_from'        => 'package',
-            'package_name'        => 'puppetboard',
-            'group'               => 'www-data',
-            'user'                => 'www-data',
-            'manage_group'        => false,
-            'manage_user'         => false,
-            'secret_key'          => 'KdDVieWrkpzbnYy5wnoCKH8HME2mcMz4',
-            'puppetdb_host'       => '127.0.0.1',
-            'puppetdb_port'       => 8081,
-            'puppetdb_ssl_verify' => '/var/www/puppetboard/ssl/ca.pem',
-            'puppetdb_key'        => '/var/www/puppetboard/ssl/private.pem',
-            'puppetdb_cert'       => '/var/www/puppetboard/ssl/public.pem',
-            'enable_catalog'      => false,
-            'enable_query'        => true,
-            'default_environment' => 'production',
-            'reports_count'       => 20,
-            'settings_file'       => '/var/www/puppetboard/settings.py',
-            'extra_settings'      => {}
-          ) }
-
-          it { is_expected.to contain_file('puppetboard service defaults').with(
-            'ensure'  => 'file',
-            'path'    => '/etc/default/puppetboard',
-            'content' => "HOST=127.0.0.1\nPORT=6000"
-          ) }
-
-          it { is_expected.to contain_class('profiles::puppet::puppetboard::certificate').with(
-            'certname' => 'puppetboard.example.com',
-            'basedir'  => '/var/www/puppetboard'
-          ) }
-
-          it { is_expected.to contain_profiles__apache__vhost__reverse_proxy('http://puppetboard.example.com').with(
-            'destination'         => 'http://127.0.0.1:6000/',
-            'aliases'             => [],
-            'auth_openid_connect' => false
-          ) }
-
-          it { is_expected.to contain_apt__source('publiq-tools').that_comes_before('Class[puppetboard]') }
-          it { is_expected.to contain_group('www-data').that_comes_before('Class[puppetboard]') }
-          it { is_expected.to contain_user('www-data').that_comes_before('Class[puppetboard]') }
-          it { is_expected.to contain_service('puppetboard').that_subscribes_to('Class[puppetboard]') }
-          it { is_expected.to contain_service('puppetboard').that_subscribes_to('File[puppetboard service defaults]') }
-          it { is_expected.to contain_service('puppetboard').that_subscribes_to('Class[profiles::puppet::puppetboard::certificate]') }
-        end
-
-        context "with servername => mypb.example.com, serveraliases => pb.example.com, service_address => 127.0.1.1, service_port => 4000, service_status => stopped and auth => true" do
-          let(:params) { {
-            'servername'      => 'mypb.example.com',
-            'serveraliases'   => 'pb.example.com',
-            'service_address' => '127.0.1.1',
-            'service_port'    => 4000,
-            'service_status'  => 'stopped',
-            'auth'            => true
-          } }
-
-          context "with hieradata" do
-            let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+          context 'with servername => puppetboard.example.com' do
+            let(:params) { {
+              'servername' => 'puppetboard.example.com'
+            } }
 
             it { is_expected.to compile.with_all_deps }
 
+            it { is_expected.to contain_class('profiles::apache') }
+
+            it { is_expected.to contain_class('profiles::puppet::puppetboard').with(
+              'servername'      => 'puppetboard.example.com',
+              'serveraliases'   => [],
+              'service_address' => '127.0.0.1',
+              'service_port'    => 6000,
+              'service_status'  => 'running',
+              'auth'            => false
+            ) }
+
+            it { is_expected.to contain_apt__source('publiq-tools') }
+            it { is_expected.to contain_group('www-data') }
+            it { is_expected.to contain_user('www-data') }
+
             it { is_expected.to contain_service('puppetboard').with(
-              'ensure'    => 'stopped',
+              'ensure'    => 'running',
               'hasstatus' => true,
-              'enable'    => false
+              'enable'    => true
+            ) }
+
+            it { is_expected.to contain_class('puppetboard').with(
+              'install_from'        => 'package',
+              'package_name'        => 'puppetboard',
+              'group'               => 'www-data',
+              'user'                => 'www-data',
+              'manage_group'        => false,
+              'manage_user'         => false,
+              'secret_key'          => 'KdDVieWrkpzbnYy5wnoCKH8HME2mcMz4',
+              'puppetdb_host'       => '127.0.0.1',
+              'puppetdb_port'       => 8081,
+              'puppetdb_ssl_verify' => '/var/www/puppetboard/ssl/ca.pem',
+              'puppetdb_key'        => '/var/www/puppetboard/ssl/private.pem',
+              'puppetdb_cert'       => '/var/www/puppetboard/ssl/public.pem',
+              'python_version'      => '3.8',
+              'enable_catalog'      => false,
+              'enable_query'        => true,
+              'default_environment' => 'production',
+              'reports_count'       => 20,
+              'settings_file'       => '/var/www/puppetboard/settings.py',
+              'extra_settings'      => {}
             ) }
 
             it { is_expected.to contain_file('puppetboard service defaults').with(
               'ensure'  => 'file',
               'path'    => '/etc/default/puppetboard',
-              'content' => "HOST=127.0.1.1\nPORT=4000"
+              'content' => "HOST=127.0.0.1\nPORT=6000"
             ) }
 
             it { is_expected.to contain_class('profiles::puppet::puppetboard::certificate').with(
-              'certname' => 'mypb.example.com',
+              'certname' => 'puppetboard.example.com',
               'basedir'  => '/var/www/puppetboard'
             ) }
 
-            it { is_expected.to contain_profiles__apache__vhost__reverse_proxy('http://mypb.example.com').with(
-              'destination'         => 'http://127.0.1.1:4000/',
-              'aliases'             => 'pb.example.com',
-              'auth_openid_connect' => true
+            it { is_expected.to contain_profiles__apache__vhost__reverse_proxy('http://puppetboard.example.com').with(
+              'destination'         => 'http://127.0.0.1:6000/',
+              'aliases'             => [],
+              'auth_openid_connect' => false
             ) }
+
+            it { is_expected.to contain_apt__source('publiq-tools').that_comes_before('Class[puppetboard]') }
+            it { is_expected.to contain_group('www-data').that_comes_before('Class[puppetboard]') }
+            it { is_expected.to contain_user('www-data').that_comes_before('Class[puppetboard]') }
+            it { is_expected.to contain_service('puppetboard').that_subscribes_to('Class[puppetboard]') }
+            it { is_expected.to contain_service('puppetboard').that_subscribes_to('File[puppetboard service defaults]') }
+            it { is_expected.to contain_service('puppetboard').that_subscribes_to('Class[profiles::puppet::puppetboard::certificate]') }
           end
 
-          context "without hieradata" do
-            let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
+          context "with servername => mypb.example.com, serveraliases => pb.example.com, service_address => 127.0.1.1, service_port => 4000, service_status => stopped and auth => true" do
+            let(:params) { {
+              'servername'      => 'mypb.example.com',
+              'serveraliases'   => 'pb.example.com',
+              'service_address' => '127.0.1.1',
+              'service_port'    => 4000,
+              'service_status'  => 'stopped',
+              'auth'            => true
+            } }
 
-            it { expect { catalogue }.to raise_error(Puppet::ParseError, /parameter 'oidc_settings' entry 'ProviderMetadataURL' expects/) }
-            it { expect { catalogue }.to raise_error(Puppet::ParseError, /parameter 'oidc_settings' entry 'ClientID' expects/) }
-            it { expect { catalogue }.to raise_error(Puppet::ParseError, /parameter 'oidc_settings' entry 'ClientSecret' expects/) }
+            context "with hieradata" do
+              let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+              it { is_expected.to compile.with_all_deps }
+
+              it { is_expected.to contain_service('puppetboard').with(
+                'ensure'    => 'stopped',
+                'hasstatus' => true,
+                'enable'    => false
+              ) }
+
+              it { is_expected.to contain_file('puppetboard service defaults').with(
+                'ensure'  => 'file',
+                'path'    => '/etc/default/puppetboard',
+                'content' => "HOST=127.0.1.1\nPORT=4000"
+              ) }
+
+              it { is_expected.to contain_class('profiles::puppet::puppetboard::certificate').with(
+                'certname' => 'mypb.example.com',
+                'basedir'  => '/var/www/puppetboard'
+              ) }
+
+              it { is_expected.to contain_profiles__apache__vhost__reverse_proxy('http://mypb.example.com').with(
+                'destination'         => 'http://127.0.1.1:4000/',
+                'aliases'             => 'pb.example.com',
+                'auth_openid_connect' => true
+              ) }
+            end
+
+            context "without hieradata" do
+              let(:hiera_config) { 'spec/support/hiera/empty.yaml' }
+
+              it { expect { catalogue }.to raise_error(Puppet::ParseError, /parameter 'oidc_settings' entry 'ProviderMetadataURL' expects/) }
+              it { expect { catalogue }.to raise_error(Puppet::ParseError, /parameter 'oidc_settings' entry 'ClientID' expects/) }
+              it { expect { catalogue }.to raise_error(Puppet::ParseError, /parameter 'oidc_settings' entry 'ClientSecret' expects/) }
+            end
           end
         end
       end

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -24,15 +24,21 @@ describe 'profiles::python' do
         context 'with all virtual resources collected' do
           let(:pre_condition) { 'Profiles::Jenkins::Node_labels <| |>' }
 
-          case facts[:os]['release']['major']
-          when '20.04'
-            it { is_expected.to contain_profiles__jenkins__node_labels('python').with(
-              'content' => 'python3.8'
-            ) }
-          when '24.04'
-            it { is_expected.to contain_profiles__jenkins__node_labels('python').with(
-              'content' => 'python3.12'
-            ) }
+          context "with Python available" do
+            case facts[:os]['release']['major']
+            when '20.04'
+              let(:facts) { facts.merge({ 'python3_release' => '3.8' }) }
+
+              it { is_expected.to contain_profiles__jenkins__node_labels('python').with(
+                'content' => 'python3.8'
+              ) }
+            when '24.04'
+              let(:facts) { facts.merge({ 'python3_release' => '3.12' }) }
+
+              it { is_expected.to contain_profiles__jenkins__node_labels('python').with(
+                'content' => 'python3.12'
+              ) }
+            end
           end
         end
       end

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -3,7 +3,7 @@ describe 'profiles::rabbitmq' do
 
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      let(:facts) { facts }
+      let(:facts) { facts.merge( { 'osfamily' => facts[:os]['family'], 'operatingsystemmajrelease' => facts[:os]['release']['major'] } ) }
 
       context "with admin_user => 'foo' and admin_password => 'bar'" do
         let(:params) { {
@@ -25,7 +25,7 @@ describe 'profiles::rabbitmq' do
         ) }
 
         it { is_expected.to contain_class('rabbitmq').with(
-          'manage_repos'      => false,
+          'repos_ensure'      => false,
           'package_ensure'    => 'latest',
           'delete_guest_user' => true
         ) }
@@ -56,7 +56,7 @@ describe 'profiles::rabbitmq' do
           ) }
 
           it { is_expected.to contain_class('rabbitmq').with(
-            'manage_repos'      => false,
+            'repos_ensure'      => false,
             'package_ensure'    => '4.5.6',
             'delete_guest_user' => true
           ) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,31 +1,36 @@
 require 'rspec-puppet'
+require 'rspec-puppet-facts'
 
 RSpec.configure do |rspec|
+  rspec.module_path = File.join(File.dirname(File.expand_path(__FILE__)), 'fixtures', 'modules')
+
   rspec.order = 'random'
   rspec.mock_with :rspec
-  rspec.after(:suite) do
-    RSpec::Puppet::Coverage.report!
-  end
+
   rspec.expect_with :rspec do |c|
     c.max_formatted_output_length = nil
   end
-  # The systemd service provider is confined to platforms that are running systemd,
-  # by checking the presence and contents of the file '/proc/1/comm'.
-  # This makes sense for a real puppet agent, but breaks when running spec tests on
-  # a platform that does not use systemd (like MacOS). We mock the calls the confine
-  # statement makes on all platforms to simulate running systemd.
-  #
-  # For more information, see: https://tickets.puppetlabs.com/browse/PUP-11167
+
   rspec.before(:each) do
+    # The systemd service provider is confined to platforms that are running systemd,
+    # by checking the presence and contents of the file '/proc/1/comm'.
+    # This makes sense for a real puppet agent, but breaks when running spec tests on
+    # a platform that does not use systemd (like MacOS). We mock the calls the confine
+    # statement makes on all platforms to simulate running systemd.
+    #
+    # For more information, see: https://tickets.puppetlabs.com/browse/PUP-11167
     allow(Puppet::FileSystem).to receive(:exist?).and_call_original
     allow(Puppet::FileSystem).to receive(:exist?).with('/proc/1/comm').and_return(true)
     allow(Puppet::FileSystem).to receive(:read).and_call_original
     allow(Puppet::FileSystem).to receive(:read).with('/proc/1/comm').and_return(['systemd'])
+    # Pretend to be running as root
+    allow(Puppet.features).to receive(:root?).and_return(true)
+  end
+
+  rspec.after(:suite) do
+    RSpec::Puppet::Coverage.report!
   end
 end
-
-require 'puppetlabs_spec_helper/module_spec_helper'
-require 'rspec-puppet-facts'
 
 include RspecPuppetFacts
 

--- a/spec/support/hiera/data/common.yaml
+++ b/spec/support/hiera/data/common.yaml
@@ -9,7 +9,7 @@ data::openid::client_id: 'abc123'
 data::openid::client_secret: 'def456'
 
 data::mysql::etl::password: 'my_etl_password'
-data::mysql::secondline_ro::password: 'my_2ndline_ro_password
+data::mysql::secondline_ro::password: 'my_2ndline_ro_password'
 
 profiles::packages::versions:
   awscli: 'latest'

--- a/spec/support/hiera/data/common.yaml
+++ b/spec/support/hiera/data/common.yaml
@@ -9,7 +9,7 @@ data::openid::client_id: 'abc123'
 data::openid::client_secret: 'def456'
 
 data::mysql::etl::password: 'my_etl_password'
-data::mysql::2ndline_ro::password: 'my_2ndline_ro_password'
+data::mysql::secondline_ro::password: 'my_2ndline_ro_password
 
 profiles::packages::versions:
   awscli: 'latest'

--- a/spec/support/hiera/data/vault.yaml
+++ b/spec/support/hiera/data/vault.yaml
@@ -1,8 +1,4 @@
 ---
-vault:testproject/testcomponent:
-  my_first_secret: 'abc123'
-  my_second_secret: 'def456'
-
 vault:uitdatabank/udb3-websocket-server: {}
 vault:uitdatabank/udb3-jwtprovider: {}
 vault:uitdatabank/uit-articlelinker: {}


### PR DESCRIPTION
We were still using the puppet gem for the tests, which cannot be updated to the
version we run on our infrastructure. Switching to the openvox gem is not that
simple though, as the puppetlabs_spec_helper requires the puppet gem.
Removing puppetlabs_spec_helper requires some other gems to be installed as
alternatives for the lost functionality.

Also, the rspec-puppet-facts needed to be updated to be able to use the openvox
gem, which removed support for legacy facts (strictly speaking, the legacy facts
will be removed in Puppet/Openvox 8, but due to the switch to Openvox I needed
to do most of it now).