### PR TITLE
Replace augeasproviders_ssh module configuration with defined type

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -24,9 +24,6 @@ fixtures:
     augeasproviders_sysctl:
       repo: 'puppet/augeasproviders_sysctl'
       ref: '3.2.0'
-    augeasproviders_ssh:
-      repo: 'puppet/augeasproviders_ssh'
-      ref: '5.0.0'
     stdlib:
       repo: 'puppetlabs/stdlib'
       ref: '8.6.0'

--- a/manifests/ssh.pp
+++ b/manifests/ssh.pp
@@ -5,22 +5,20 @@ class profiles::ssh(
   include ::profiles::firewall::rules
   include ::profiles::ssh_authorized_keys
 
-  Sshd_config {
-    notify  => Service['ssh']
-  }
-
   package { 'openssh-server':
     ensure => 'latest',
     notify => Service['ssh']
   }
 
-  sshd_config { 'PermitRootLogin':
+  profiles::ssh::sshd_config { 'PermitRootLogin':
     ensure => 'present',
-    value  => 'no'
+    value  => 'no',
+    notify  => Service['ssh']
   }
 
-  sshd_config { 'PubkeyAcceptedKeyTypes':
-    ensure => 'absent'
+  profiles::ssh::sshd_config { 'PubkeyAcceptedKeyTypes':
+    ensure => 'absent',
+    notify  => Service['ssh']
   }
 
   service { 'ssh':
@@ -37,8 +35,7 @@ class profiles::ssh(
   if $settings::storeconfigs {
     @@sshkey { "${facts['networking']['hostname']}@ssh-rsa":
       key          => $facts['ssh']['rsa']['key'],
-      host_aliases => [$facts['networking']['ip'], $facts['networking']['fqdn']],
-      provider     => 'parsed'
+      host_aliases => [$facts['networking']['ip'], $facts['networking']['fqdn']]
     }
 
     Sshkey <<| |>>

--- a/manifests/ssh/sshd_config.pp
+++ b/manifests/ssh/sshd_config.pp
@@ -1,0 +1,25 @@
+define profiles::ssh::sshd_config (
+  Enum['present', 'absent'] $ensure = 'present',
+  Variant                   $value  = undef
+) {
+
+  case $ensure {
+    'present': {
+      if $value {
+        $augeas_command = "set ${title} '${value}'"
+      } else {
+        fail("Value cannot be nil when ensure is 'present'")
+      }
+    }
+    'absent': {
+      $augeas_command = "rm ${title}"
+    }
+  }
+
+  augeas { "Sshd_config ${title}":
+    lens    => 'Sshd.lns',
+    incl    => '/etc/ssh/sshd_config',
+    context => '/files/etc/ssh/sshd_config',
+    changes => $augeas_command
+  }
+}

--- a/spec/classes/ssh_spec.rb
+++ b/spec/classes/ssh_spec.rb
@@ -16,16 +16,14 @@ describe 'profiles::ssh' do
           'ensure' => 'latest'
         ) }
 
-        it { is_expected.to contain_sshd_config('PermitRootLogin').with(
+        it { is_expected.to contain_profiles__ssh__sshd_config('PermitRootLogin').with(
           'ensure' => 'present',
           'value'  => 'no'
         ) }
 
-        it { is_expected.to contain_sshd_config('PubkeyAcceptedKeyTypes').with(
+        it { is_expected.to contain_profiles__ssh__sshd_config('PubkeyAcceptedKeyTypes').with(
           'ensure' => 'absent'
         ) }
-
-        it { is_expected.to contain_sshd_config('PermitRootLogin').that_notifies('Service[ssh]') }
 
         it { is_expected.to contain_service('ssh').with(
           'ensure' => 'running',
@@ -54,6 +52,8 @@ describe 'profiles::ssh' do
 
         it { is_expected.to have_ssh_authorized_key_resource_count(0) }
 
+        it { is_expected.to contain_profiles__ssh__sshd_config('PermitRootLogin').that_notifies('Service[ssh]') }
+        it { is_expected.to contain_profiles__ssh__sshd_config('PubkeyAcceptedKeyTypes').that_notifies('Service[ssh]') }
         it { is_expected.to contain_package('openssh-server').that_notifies('Service[ssh]') }
       end
 

--- a/spec/defines/ssh/sshd_config_spec.rb
+++ b/spec/defines/ssh/sshd_config_spec.rb
@@ -1,0 +1,80 @@
+describe 'profiles::ssh::sshd_config' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      context 'with title => foo' do
+        let(:title) { 'foo' }
+
+        context 'with value => true' do
+          let(:params) { {
+            'value' => true
+          } }
+
+          it { is_expected.to compile.with_all_deps }
+
+          it { is_expected.to contain_profiles__ssh__sshd_config('foo').with(
+            'ensure' => 'present',
+            'value'  => true
+          ) }
+
+          it { is_expected.to contain_augeas('Sshd_config foo').with(
+            'lens'    => 'Sshd.lns',
+            'incl'    => '/etc/ssh/sshd_config',
+            'context' => '/files/etc/ssh/sshd_config',
+            'changes' => "set foo 'true'"
+          ) }
+        end
+
+        context 'with ensure => absent' do
+          let(:params) { {
+            'ensure' => 'absent'
+          } }
+
+          it { is_expected.to contain_augeas('Sshd_config foo').with(
+            'lens'    => 'Sshd.lns',
+            'incl'    => '/etc/ssh/sshd_config',
+            'context' => '/files/etc/ssh/sshd_config',
+            'changes' => "rm foo"
+          ) }
+        end
+
+        context 'with value => bar' do
+          let(:params) { {
+            'value' => 'bar'
+          } }
+
+          it { is_expected.to contain_augeas('Sshd_config foo').with(
+            'lens'    => 'Sshd.lns',
+            'incl'    => '/etc/ssh/sshd_config',
+            'context' => '/files/etc/ssh/sshd_config',
+            'changes' => "set foo 'bar'"
+          ) }
+        end
+      end
+
+      context 'with title => PermitRootLogin' do
+        let(:title) { 'PermitRootLogin' }
+
+        context 'with value => no' do
+          let(:params) { {
+            'value' => 'no'
+          } }
+
+          it { is_expected.to contain_augeas('Sshd_config PermitRootLogin').with(
+            'lens'    => 'Sshd.lns',
+            'incl'    => '/etc/ssh/sshd_config',
+            'context' => '/files/etc/ssh/sshd_config',
+            'changes' => "set PermitRootLogin 'no'"
+          ) }
+        end
+
+        context 'without parameters' do
+          let(:params) { {} }
+
+          it { expect { catalogue }.to raise_error(Puppet::ParseError, /Value cannot be nil when ensure is 'present'/) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- **Provide a simple augeas based defined type for sshd_config keys with string values**
- **Move the sshd_config resources to defined type profiles::ssh::sshd_config**
- **Remove unused augeasproviders_ssh module**
