### PR TITLE
Allow specifying PostgreSQL version for puppetdb profile

### DIFF
--- a/manifests/apt/repositories.pp
+++ b/manifests/apt/repositories.pp
@@ -176,6 +176,15 @@ class profiles::apt::repositories {
     }
   }
 
+  if $facts['os']['release']['major'] == '20.04' {
+    @apt::source { 'postgresql':
+      location     => "https://apt-mirror.publiq.be/postgresql-${codename}-${environment}",
+      release      => $codename,
+      architecture => $arch,
+      repos        => 'main'
+    }
+  }
+
   # Project repositories
   @apt::source { 'uit-mail-subscriptions':
     location => "https://apt.publiq.be/uit-mail-subscriptions-${environment}",

--- a/manifests/puppet/puppetdb.pp
+++ b/manifests/puppet/puppetdb.pp
@@ -1,5 +1,6 @@
 class profiles::puppet::puppetdb (
   String                     $version           = 'installed',
+  Enum['12', '14']           $postgres_version  = '12',
   Optional[String]           $certname          = $facts['networking']['fqdn'],
   Optional[String]           $initial_heap_size = undef,
   Optional[String]           $maximum_heap_size = undef,
@@ -20,6 +21,10 @@ class profiles::puppet::puppetdb (
   realize User['puppetdb']
   realize Apt::Source['openvox']
 
+  if $facts['os']['release']['major'] == '20.04' and $postgres_version != '12' {
+    realize Apt::Source['postgresql']
+  }
+
   realize Firewall['300 accept puppetdb HTTPS traffic']
 
   include profiles::java
@@ -35,7 +40,7 @@ class profiles::puppet::puppetdb (
 
   class { 'puppetdb::database::postgresql':
     manage_package_repo => false,
-    postgres_version    => '12',
+    postgres_version    => $postgres_version,
     listen_addresses    => '127.0.0.1',
     require             => [Group['postgres'], User['postgres'], Class['puppetdb::globals']]
   }

--- a/spec/classes/apt/repositories_spec.rb
+++ b/spec/classes/apt/repositories_spec.rb
@@ -60,6 +60,7 @@ describe 'profiles::apt::repositories' do
             include_examples 'apt repositories', 'elastic-8.x', { :location => 'https://apt-mirror.publiq.be/elastic-8.x-testing', :repos => 'main', :release => 'stable' }
             include_examples 'apt repositories', 'hashicorp', { :location => 'https://apt-mirror.publiq.be/hashicorp-focal-testing', :repos => 'main', :release => 'focal' }
             include_examples 'apt repositories', 'openvox', { :location => 'https://apt-mirror.publiq.be/openvox-focal-testing', :repos => 'main', :release => 'focal' }
+            include_examples 'apt repositories', 'postgresql', { :location => 'https://apt-mirror.publiq.be/postgresql-focal-testing', :repos => 'main', :release => 'focal' }
 
             it { is_expected.not_to contain_apt__source('mysql-8.4') }
 
@@ -115,6 +116,8 @@ describe 'profiles::apt::repositories' do
 
             include_examples 'apt repositories', 'php', { :location => 'https://apt-mirror.publiq.be/php-noble-acceptance', :repos => 'main', :release => 'noble' }
             include_examples 'apt repositories', 'mysql-8.4', { :location => 'https://apt-mirror.publiq.be/mysql-8.4-noble-acceptance', :repos => 'mysql-8.4-lts', :release => 'noble' }
+
+            it { is_expected.not_to contain_apt__source('postgresql') }
           end
         end
       end

--- a/spec/classes/puppet/puppetdb_spec.rb
+++ b/spec/classes/puppet/puppetdb_spec.rb
@@ -15,6 +15,7 @@ describe 'profiles::puppet::puppetdb' do
 
           it { is_expected.to contain_class('profiles::puppet::puppetdb').with(
             'version'           => 'installed',
+            'postgres_version'  => '12',
             'certname'          => 'aaa.example.com',
             'initial_heap_size' => nil,
             'maximum_heap_size' => nil,
@@ -25,6 +26,7 @@ describe 'profiles::puppet::puppetdb' do
           it { is_expected.to contain_user('puppetdb') }
 
           it { is_expected.to contain_apt__source('openvox') }
+          it { is_expected.not_to contain_apt__source('postgresql') }
           it { is_expected.to contain_firewall('300 accept puppetdb HTTPS traffic') }
 
           it { is_expected.to contain_class('profiles::java') }
@@ -69,9 +71,10 @@ describe 'profiles::puppet::puppetdb' do
           it { is_expected.to contain_class('puppetdb::server').that_requires('Class[puppetdb::database::postgresql]') }
         end
 
-        context "with version => 7.2.3, certname => puppetdb.example.com, initial_heap_size => 512m, maximum_heap_size => 512m and service_status => stopped" do
+        context "with version => 7.2.3, postgres_version => 14, certname => puppetdb.example.com, initial_heap_size => 512m, maximum_heap_size => 512m and service_status => stopped" do
           let(:params) { {
             'version'           => '7.2.3',
+            'postgres_version'  => '14',
             'certname'          => 'puppetdb.example.com',
             'initial_heap_size' => '512m',
             'maximum_heap_size' => '512m',
@@ -80,12 +83,25 @@ describe 'profiles::puppet::puppetdb' do
 
           it { is_expected.to compile.with_all_deps }
 
+          case facts[:os]['release']['major']
+          when '20.04'
+            it { is_expected.to contain_apt__source('postgresql') }
+          when '24.04'
+            it { is_expected.not_to contain_apt__source('postgresql') }
+          end
+
           it { is_expected.to contain_class('profiles::puppet::puppetdb::certificate').with(
             'certname' => 'puppetdb.example.com'
           ) }
 
           it { is_expected.to contain_class('puppetdb::globals').with(
             'version' => '7.2.3'
+          ) }
+
+          it { is_expected.to contain_class('puppetdb::database::postgresql').with(
+            'manage_package_repo' => false,
+            'postgres_version'    => '14',
+            'listen_addresses'    => '127.0.0.1'
           ) }
 
           it { is_expected.to contain_class('puppetdb::server').with(


### PR DESCRIPTION
- **We need a PostgreSQL mirror for Ubuntu 20.04 to install PostgreSQL 14**
- **Allow specifying PostgreSQL version for puppetdb profile**
