### PR TITLE
Upgrade modules to a version compatible with stdlib >= 9.0.0 where possible

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -135,10 +135,13 @@ fixtures:
     debconf:
       repo: 'stm/debconf'
       ref: '6.2.0'
+    python:
+      repo: 'puppet/python'
+      ref: '7.4.0'
   repositories:
     filebeat:
       repo: 'https://github.com/cultuurnet/puppet-filebeat.git'
-      ref: 'dddb0b7'
+      ref: '58c0f6c'
     borgbackup:
       repo: 'https://github.com/cultuurnet/puppet-borgbackup.git'
       ref: '0c92c9b'

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -141,7 +141,7 @@ fixtures:
   repositories:
     filebeat:
       repo: 'https://github.com/cultuurnet/puppet-filebeat.git'
-      ref: '58c0f6c'
+      ref: '598539b'
     borgbackup:
       repo: 'https://github.com/cultuurnet/puppet-borgbackup.git'
       ref: '0c92c9b'

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -17,13 +17,13 @@ fixtures:
       ref: '1.3.0'
     augeasproviders_core:
       repo: 'puppet/augeasproviders_core'
-      ref: '3.2.1'
+      ref: '4.2.0'
     augeasproviders_shellvar:
       repo: 'puppet/augeasproviders_shellvar'
-      ref: '5.0.0'
+      ref: '6.0.1'
     augeasproviders_sysctl:
       repo: 'puppet/augeasproviders_sysctl'
-      ref: '3.2.0'
+      ref: '3.3.0'
     stdlib:
       repo: 'puppetlabs/stdlib'
       ref: '8.6.0'
@@ -44,13 +44,13 @@ fixtures:
       ref: '10.1.0'
     apache:
       repo: 'puppetlabs/apache'
-      ref: '9.1.3'
+      ref: '11.1.0'
     nodejs:
       repo: 'puppet/nodejs'
-      ref: '9.1.0'
+      ref: '10.0.0'
     elasticsearch:
       repo: 'puppet/elasticsearch'
-      ref: '8.1.0'
+      ref: '9.0.0'
     firewall:
       repo: 'puppetlabs/firewall'
       ref: '3.6.0'
@@ -62,10 +62,10 @@ fixtures:
       ref: '8.0.0'
     systemd:
       repo: 'puppet/systemd'
-      ref: '4.2.0'
+      ref: '5.2.0'
     redis:
       repo: 'puppet/redis'
-      ref: '8.8.0'
+      ref: '9.1.0'
     alternatives:
       repo: 'puppet/alternatives'
       ref: '3.0.0'
@@ -77,13 +77,13 @@ fixtures:
       ref: '2.2.0'
     docker:
       repo: 'puppetlabs/docker'
-      ref: '4.1.2'
+      ref: '5.1.0'
     timezone:
       repo: 'saz/timezone'
       ref: '7.0.0'
     collectd:
       repo: 'puppet/collectd'
-      ref: '13.0.0'
+      ref: '15.0.0'
     postgresql:
       repo: 'puppetlabs/postgresql'
       ref: '8.2.1'
@@ -101,22 +101,22 @@ fixtures:
       ref: '1.0.0'
     hiera:
       repo: 'puppet/hiera'
-      ref: '5.0.1'
+      ref: '6.0.0'
     fail2ban:
       repo: 'puppet/fail2ban'
-      ref: '4.2.0'
+      ref: '5.0.2'
     php:
       repo: 'puppet/php'
-      ref: '8.2.0'
+      ref: '9.0.0'
     logrotate:
       repo: 'puppet/logrotate'
-      ref: '6.1.0'
+      ref: '7.0.0'
     docker:
       repo: 'puppetlabs/docker'
       ref: '5.1.0'
     puppetboard:
       repo: 'puppet/puppetboard'
-      ref: '10.0.0'
+      ref: '11.0.0'
     mongodb:
       repo: 'puppet/mongodb'
       ref: '5.0.0'
@@ -131,14 +131,14 @@ fixtures:
       ref: '13.4.0'
     archive:
       repo: 'puppet/archive'
-      ref: '6.1.2'
+      ref: '7.1.0'
     debconf:
       repo: 'stm/debconf'
       ref: '6.2.0'
   repositories:
     filebeat:
       repo: 'https://github.com/cultuurnet/puppet-filebeat.git'
-      ref: '598539b'
+      ref: 'dddb0b7'
     borgbackup:
       repo: 'https://github.com/cultuurnet/puppet-borgbackup.git'
       ref: '0c92c9b'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2.3
+          ruby-version: 2.7.0
 
       - name: Install dependencies
         run: bundle install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.0
+          ruby-version: 3.2.3
 
       - name: Install dependencies
         run: bundle install

--- a/metadata.json
+++ b/metadata.json
@@ -14,8 +14,7 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "20.04",
-        "24.04"
+        "20.04"
       ]
     }
   ],

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -20,7 +20,7 @@ describe 'profiles::nodejs' do
 
         it { is_expected.to contain_class('nodejs').with(
           'manage_package_repo'   => false,
-          'nodejs_package_ensure' => 'present'
+          'nodejs_package_ensure' => 'installed'
         ) }
 
         it { is_expected.not_to contain_profiles__jenkins__node_labels('nodejs') }
@@ -49,7 +49,7 @@ describe 'profiles::nodejs' do
 
         it { is_expected.to contain_class('nodejs').with(
           'manage_package_repo'   => false,
-          'nodejs_package_ensure' => 'present'
+          'nodejs_package_ensure' => 'installed'
         ) }
 
         it { is_expected.not_to contain_profiles__jenkins__node_labels('nodejs') }


### PR DESCRIPTION
First step in upgrading modules: minimal upgrade to a version compatible with the stdlib module >= 9.0.0.
