### PR TITLE
Upgrade stdlib module and remaining modules to satisfy the version requirements

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -26,16 +26,16 @@ fixtures:
       ref: '3.3.0'
     stdlib:
       repo: 'puppetlabs/stdlib'
-      ref: '8.6.0'
+      ref: '9.7.0'
     concat:
       repo: 'puppetlabs/concat'
-      ref: '7.4.0'
+      ref: '9.1.0'
     postfix:
       repo: 'thias/postfix'
       ref: '0.3.8'
     apt:
       repo: 'puppetlabs/apt'
-      ref: '8.4.0'
+      ref: '9.4.0'
     lvm:
       repo: 'puppetlabs/lvm'
       ref: '2.1.0'
@@ -53,7 +53,7 @@ fixtures:
       ref: '9.0.0'
     firewall:
       repo: 'puppetlabs/firewall'
-      ref: '3.6.0'
+      ref: '6.0.0'
     inifile:
       repo: 'puppetlabs/inifile'
       ref: '1.6.0'
@@ -71,13 +71,13 @@ fixtures:
       ref: '3.0.0'
     gnupg:
       repo: 'h0tw1r3/gnupg'
-      ref: '1.5.2'
+      ref: '2.0.2'
     java_ks:
       repo: 'puppetlabs/java_ks'
       ref: '2.2.0'
     docker:
       repo: 'puppetlabs/docker'
-      ref: '5.1.0'
+      ref: '8.0.0'
     timezone:
       repo: 'saz/timezone'
       ref: '7.0.0'
@@ -86,10 +86,10 @@ fixtures:
       ref: '15.0.0'
     postgresql:
       repo: 'puppetlabs/postgresql'
-      ref: '8.2.1'
+      ref: '9.2.0'
     puppetdb:
       repo: 'puppetlabs/puppetdb'
-      ref: '7.13.0'
+      ref: '7.14.0'
     hocon:
       repo: 'puppetlabs/hocon'
       ref: '1.1.0'
@@ -107,13 +107,13 @@ fixtures:
       ref: '5.0.2'
     php:
       repo: 'puppet/php'
-      ref: '9.0.0'
+      ref: '11.0.0'
     logrotate:
       repo: 'puppet/logrotate'
       ref: '7.0.0'
     docker:
       repo: 'puppetlabs/docker'
-      ref: '5.1.0'
+      ref: '8.0.0'
     puppetboard:
       repo: 'puppet/puppetboard'
       ref: '11.0.0'
@@ -122,7 +122,7 @@ fixtures:
       ref: '5.0.0'
     puppet-openssl:
       repo: 'puppet/openssl'
-      ref: '2.0.1'
+      ref: '3.2.0'
     rsyslog:
       repo: 'puppet/rsyslog'
       ref: '7.3.0'
@@ -138,10 +138,13 @@ fixtures:
     python:
       repo: 'puppet/python'
       ref: '7.4.0'
+    mysql:
+      repo: 'puppetlabs/mysql'
+      ref: '16.3.0'
   repositories:
     filebeat:
       repo: 'https://github.com/cultuurnet/puppet-filebeat.git'
-      ref: '598539b'
+      ref: '2008f2e'
     borgbackup:
       repo: 'https://github.com/cultuurnet/puppet-borgbackup.git'
       ref: '0c92c9b'
@@ -151,9 +154,6 @@ fixtures:
     aptly:
       repo: 'https://github.com/cultuurnet/puppet-aptly.git'
       ref: '2d5031b'
-    mysql:
-      repo: 'https://github.com/cultuurnet/puppetlabs-mysql.git'
-      ref: '844aa07'
   symlinks:
     appconfig: ${PWD}/spec/support/appconfig
     profiles: ${PWD}

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -153,7 +153,7 @@ fixtures:
       ref: '0c92c9b'
     glassfish:
       repo: 'https://github.com/cultuurnet/fatmcgav-glassfish.git'
-      ref: 'c8178d0'
+      ref: 'cb923fa'
   symlinks:
     appconfig: ${PWD}/spec/support/appconfig
     profiles: ${PWD}

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -141,6 +141,9 @@ fixtures:
     mysql:
       repo: 'puppetlabs/mysql'
       ref: '16.3.0'
+    aptly:
+      repo: 'puppet/aptly'
+      ref: '2.3.0'
   repositories:
     filebeat:
       repo: 'https://github.com/cultuurnet/puppet-filebeat.git'
@@ -150,10 +153,7 @@ fixtures:
       ref: '0c92c9b'
     glassfish:
       repo: 'https://github.com/cultuurnet/fatmcgav-glassfish.git'
-      ref: 'f91d0b6f'
-    aptly:
-      repo: 'https://github.com/cultuurnet/puppet-aptly.git'
-      ref: '2d5031b'
+      ref: '9bb2ceb'
   symlinks:
     appconfig: ${PWD}/spec/support/appconfig
     profiles: ${PWD}

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -53,7 +53,7 @@ fixtures:
       ref: '9.0.0'
     firewall:
       repo: 'puppetlabs/firewall'
-      ref: '6.0.0'
+      ref: '7.0.2'
     inifile:
       repo: 'puppetlabs/inifile'
       ref: '1.6.0'
@@ -62,10 +62,10 @@ fixtures:
       ref: '8.0.0'
     systemd:
       repo: 'puppet/systemd'
-      ref: '5.2.0'
+      ref: '8.3.1'
     redis:
       repo: 'puppet/redis'
-      ref: '9.1.0'
+      ref: '11.1.0'
     alternatives:
       repo: 'puppet/alternatives'
       ref: '3.0.0'
@@ -86,10 +86,10 @@ fixtures:
       ref: '15.0.0'
     postgresql:
       repo: 'puppetlabs/postgresql'
-      ref: '9.2.0'
+      ref: '10.5.0'
     puppetdb:
       repo: 'puppetlabs/puppetdb'
-      ref: '7.14.0'
+      ref: '8.0.0'
     hocon:
       repo: 'puppetlabs/hocon'
       ref: '1.1.0'

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -153,7 +153,7 @@ fixtures:
       ref: '0c92c9b'
     glassfish:
       repo: 'https://github.com/cultuurnet/fatmcgav-glassfish.git'
-      ref: '9bb2ceb'
+      ref: 'c8178d0'
   symlinks:
     appconfig: ${PWD}/spec/support/appconfig
     profiles: ${PWD}

--- a/manifests/aptly.pp
+++ b/manifests/aptly.pp
@@ -61,7 +61,7 @@ class profiles::aptly (
     user           => 'aptly',
     config         => {
                         'rootDir'            => $data_dir,
-                        'architectures'      => 'amd64',
+                        'architectures'      => ['amd64'],
                         'S3PublishEndpoints' => $publish_endpoints
                       },
     require        => [Apt::Source['aptly'], User['aptly']],

--- a/manifests/aptly.pp
+++ b/manifests/aptly.pp
@@ -53,6 +53,14 @@ class profiles::aptly (
       options => 'rw,bind',
       require => [Profiles::Lvm::Mount['aptlydata'], Class['::aptly']]
     }
+  } else {
+    file { $data_dir:
+      ensure  => 'directory',
+      owner   => 'aptly',
+      group   => 'aptly',
+      require => [Group['aptly'], User['aptly']],
+      before  => Class['::aptly']
+    }
   }
 
   class { '::aptly':

--- a/manifests/aptly.pp
+++ b/manifests/aptly.pp
@@ -10,8 +10,8 @@ class profiles::aptly (
   Hash                           $publish_endpoints = {},
   Hash                           $repositories      = {},
   Hash                           $mirrors           = {},
-  Boolean                        $lvm               = false,
   Variant[String, Array[String]] $architectures     = 'amd64',
+  Boolean                        $lvm               = false,
   Optional[String]               $volume_group      = undef,
   Optional[String]               $volume_size       = undef
 ) inherits ::profiles {
@@ -56,25 +56,23 @@ class profiles::aptly (
   }
 
   class { '::aptly':
-    version              => $version,
-    install_repo         => false,
-    manage_user          => false,
-    root_dir             => $data_dir,
-    enable_service       => false,
-    enable_api           => true,
-    api_bind             => $api_bind,
-    api_port             => $api_port,
-    api_nolock           => true,
-    architectures        => [$architectures].flatten,
-    require              => [Apt::Source['aptly'], User['aptly']],
-    s3_publish_endpoints => $publish_endpoints
+    package_ensure => $version,
+    repo           => false,
+    user           => 'aptly',
+    config         => {
+                        'rootDir'            => $data_dir,
+                        'architectures'      => 'amd64',
+                        'S3PublishEndpoints' => $publish_endpoints
+                      },
+    require        => [Apt::Source['aptly'], User['aptly']],
   }
 
-  systemd::unit_file { 'aptly-api.service':
-    content => template('profiles/aptly/aptly-api.service.erb'),
-    enable  => true,
-    active  => true,
-    require => Class['aptly']
+  class { '::aptly::api':
+    user                => 'aptly',
+    group               => 'aptly',
+    listen              => "${api_bind}:${api_port}",
+    enable_cli_and_http => true,
+    require             => [Class['::aptly'], Group['aptly'], User['aptly']]
   }
 
   if $certificate {
@@ -131,13 +129,13 @@ class profiles::aptly (
     $archive = $attributes['archive']
 
     aptly::repo { $repo:
-      default_component => 'main'
+      component => 'main'
     }
 
     if $archive {
       aptly::repo { "${repo}-archive":
-        default_component => 'main',
-        require           => Aptly::Repo[$repo]
+        component => 'main',
+        require   => Aptly::Repo[$repo]
       }
     }
 
@@ -174,10 +172,9 @@ class profiles::aptly (
 
       aptly::mirror { $mirror:
         location      => $attributes['location'],
-        distribution  => $attributes['distribution'],
-        components    => [$attributes['components']].flatten,
+        release       => $attributes['distribution'],
+        repos         => [$attributes['components']].flatten,
         architectures => [$attributes['architectures']].flatten,
-        update        => false,
         keyring       => "${home_dir}/.gnupg/trustedkeys.gpg",
         require       => File['aptly trustedkeys.gpg']
       }

--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -9,32 +9,32 @@ class profiles::firewall (
   }
 
   firewall { '000 accept all ICMP traffic':
-    proto  => 'icmp',
-    action => 'accept'
+    proto => 'icmp',
+    jump  => 'accept'
   }
 
   firewall { '001 accept all traffic to lo interface':
     proto   => 'all',
     iniface => 'lo',
-    action  => 'accept'
+    jump    => 'accept'
   }
 
   firewall { '002 reject local traffic not on loopback interface':
     proto       => 'all',
     iniface     => '! lo',
     destination => '127.0.0.0/8',
-    action      => 'reject'
+    jump        => 'reject'
   }
 
   firewall { '003 accept related established rules':
-    proto  => 'all',
-    state  => ['RELATED', 'ESTABLISHED'],
-    action => 'accept'
+    proto => 'all',
+    state => ['RELATED', 'ESTABLISHED'],
+    jump  => 'accept'
   }
 
   firewall { '999 drop all':
     proto  => 'all',
-    action => 'drop',
+    jump   => 'drop',
     before => undef
   }
 }

--- a/manifests/firewall/rules.pp
+++ b/manifests/firewall/rules.pp
@@ -1,109 +1,109 @@
 class profiles::firewall::rules inherits ::profiles {
 
   @firewall { '100 accept SSH traffic':
-    proto  => 'tcp',
-    dport  => '22',
-    action => 'accept'
+    proto => 'tcp',
+    dport => '22',
+    jump  => 'accept'
   }
 
   @firewall { '300 accept HTTP traffic':
-    proto  => 'tcp',
-    dport  => '80',
-    action => 'accept'
+    proto => 'tcp',
+    dport => '80',
+    jump  => 'accept'
   }
 
   @firewall { '300 accept webcache traffic':
-    proto  => 'tcp',
-    dport  => '8080',
-    action => 'accept'
+    proto => 'tcp',
+    dport => '8080',
+    jump  => 'accept'
   }
 
   @firewall { '300 accept HTTPS traffic':
-    proto  => 'tcp',
-    dport  => '443',
-    action => 'accept'
+    proto => 'tcp',
+    dport => '443',
+    jump  => 'accept'
   }
 
   @firewall { '300 accept puppetserver HTTPS traffic':
-    proto  => 'tcp',
-    dport  => '8140',
-    action => 'accept'
+    proto => 'tcp',
+    dport => '8140',
+    jump  => 'accept'
   }
 
   @firewall { '300 accept puppetdb HTTPS traffic':
-    proto  => 'tcp',
-    dport  => '8081',
-    action => 'accept'
+    proto => 'tcp',
+    dport => '8081',
+    jump  => 'accept'
   }
 
   @firewall { '300 accept SMTP traffic':
-    proto  => 'tcp',
-    dport  => '25',
-    action => 'accept'
+    proto => 'tcp',
+    dport => '25',
+    jump  => 'accept'
   }
 
   @firewall { '400 accept redis traffic':
-    proto  => 'tcp',
-    dport  => '6379',
-    action => 'accept'
+    proto => 'tcp',
+    dport => '6379',
+    jump  => 'accept'
   }
 
   @firewall { '400 accept meilisearch traffic':
-    proto  => 'tcp',
-    dport  => '7700',
-    action => 'accept'
+    proto => 'tcp',
+    dport => '7700',
+    jump  => 'accept'
   }
 
   @firewall { '400 accept mysql traffic':
-    proto  => 'tcp',
-    dport  => '3306',
-    action => 'accept'
+    proto => 'tcp',
+    dport => '3306',
+    jump  => 'accept'
   }
 
   @firewall { '400 accept vault traffic':
-    proto  => 'tcp',
-    dport  => '8200',
-    action => 'accept'
+    proto => 'tcp',
+    dport => '8200',
+    jump  => 'accept'
   }
 
   @firewall { '400 accept mongodb traffic':
-    proto  => 'tcp',
-    dport  => '27017',
-    action => 'accept'
+    proto => 'tcp',
+    dport => '27017',
+    jump  => 'accept'
   }
 
   @firewall { '400 accept mailpit SMTP traffic':
-    proto  => 'tcp',
-    dport  => '1025',
-    action => 'accept'
+    proto => 'tcp',
+    dport => '1025',
+    jump  => 'accept'
   }
 
   @firewall { '400 accept logstash filebeat traffic':
-    proto  => 'tcp',
-    dport  => '5000',
-    action => 'accept'
+    proto => 'tcp',
+    dport => '5000',
+    jump  => 'accept'
   }
 
   @firewall { '500 accept carbon traffic':
-    proto  => 'tcp',
-    dport  => '2003',
-    action => 'accept'
+    proto => 'tcp',
+    dport => '2003',
+    jump  => 'accept'
   }
 
   @firewall { '600 accept elasticsearch http traffic':
-    proto  => 'tcp',
-    dport  => '9200',
-    action => 'accept'
+    proto => 'tcp',
+    dport => '9200',
+    jump  => 'accept'
   }
 
   @firewall { '600 accept elasticsearch cluster traffic':
-    proto  => 'tcp',
-    dport  => '9300',
-    action => 'accept'
+    proto => 'tcp',
+    dport => '9300',
+    jump  => 'accept'
   }
   @firewall { '600 accept docker ephemeral ports traffic':
-    proto  => 'tcp',
-    dport  => '32768-60999',
-    action => 'accept'
+    proto => 'tcp',
+    dport => '32768-60999',
+    jump  => 'accept'
   }
 }

--- a/manifests/glassfish/domain.pp
+++ b/manifests/glassfish/domain.pp
@@ -56,15 +56,15 @@ define profiles::glassfish::domain (
   }
 
   firewall { "400 accept glassfish domain ${title} HTTP traffic":
-    proto  => 'tcp',
-    dport  => String($portbase + 80),
-    action => 'accept'
+    proto => 'tcp',
+    dport => String($portbase + 80),
+    jump  => 'accept'
   }
 
   firewall { "400 accept glassfish domain ${title} HTTPS traffic":
-    proto  => 'tcp',
-    dport  => String($portbase + 81),
-    action => 'accept'
+    proto => 'tcp',
+    dport => String($portbase + 81),
+    jump  => 'accept'
   }
 
   cron { "Cleanup payara logs ${title}":

--- a/manifests/projectaanvraag/api/amqp_consumer.pp
+++ b/manifests/projectaanvraag/api/amqp_consumer.pp
@@ -7,10 +7,7 @@ class profiles::projectaanvraag::api::amqp_consumer (
   realize User['www-data']
 
   systemd::unit_file { 'projectaanvraag-api-amqp-consumer.service':
-    ensure  => $ensure ? {
-                 'absent'  => 'absent',
-                 'present' => 'file'
-               },
+    ensure  => $ensure,
     content => template('profiles/projectaanvraag/api/projectaanvraag-api-amqp-consumer.service.erb'),
     notify  => Service['projectaanvraag-api-amqp-consumer']
   }

--- a/manifests/systemd/service_watchdog.pp
+++ b/manifests/systemd/service_watchdog.pp
@@ -14,10 +14,7 @@ define profiles::systemd::service_watchdog (
   }
 
   file { "${title}-watchdog":
-    ensure  => $ensure ? {
-                 'absent'  => 'absent',
-                 'present' => 'file'
-               },
+    ensure  => $ensure,
     path    => "/usr/local/bin/${title}-watchdog",
     owner   => 'root',
     group   => 'root',

--- a/manifests/systemd/service_watchdog.pp
+++ b/manifests/systemd/service_watchdog.pp
@@ -14,7 +14,10 @@ define profiles::systemd::service_watchdog (
   }
 
   file { "${title}-watchdog":
-    ensure  => $ensure,
+    ensure  => $ensure ? {
+                 'absent'  => 'absent',
+                 'present' => 'file'
+               },
     path    => "/usr/local/bin/${title}-watchdog",
     owner   => 'root',
     group   => 'root',
@@ -24,10 +27,7 @@ define profiles::systemd::service_watchdog (
   }
 
   systemd::unit_file { "${title}-watchdog.service":
-    ensure  => $ensure ? {
-                 'absent'  => 'absent',
-                 'present' => 'file'
-               },
+    ensure  => $ensure,
     content => template('profiles/systemd/service_watchdog.service.erb'),
     notify  => Service["${title}-watchdog"]
   }

--- a/manifests/uitdatabank/entry_api/amqp_listener_uitpas.pp
+++ b/manifests/uitdatabank/entry_api/amqp_listener_uitpas.pp
@@ -7,10 +7,7 @@ class profiles::uitdatabank::entry_api::amqp_listener_uitpas (
   realize User['www-data']
 
   systemd::unit_file { 'uitdatabank-amqp-listener-uitpas.service':
-    ensure        => $ensure ? {
-                       'absent'  => 'absent',
-                       'present' => 'file'
-                     },
+    ensure        => $ensure,
     content       => template('profiles/uitdatabank/entry_api/uitdatabank-amqp-listener-uitpas.service.erb'),
     notify        => Service['uitdatabank-amqp-listener-uitpas']
   }

--- a/manifests/uitdatabank/entry_api/bulk_label_offer_worker.pp
+++ b/manifests/uitdatabank/entry_api/bulk_label_offer_worker.pp
@@ -7,10 +7,7 @@ class profiles::uitdatabank::entry_api::bulk_label_offer_worker (
   realize User['www-data']
 
   systemd::unit_file { 'uitdatabank-bulk-label-offer-worker.service':
-    ensure        => $ensure ? {
-                       'absent'  => 'absent',
-                       'present' => 'file'
-                     },
+    ensure        => $ensure,
     content       => template('profiles/uitdatabank/entry_api/uitdatabank-bulk-label-offer-worker.service.erb'),
     notify        => Service['uitdatabank-bulk-label-offer-worker']
   }

--- a/manifests/uitdatabank/entry_api/event_export_workers.pp
+++ b/manifests/uitdatabank/entry_api/event_export_workers.pp
@@ -10,7 +10,7 @@ class profiles::uitdatabank::entry_api::event_export_workers (
   systemd::unit_file { 'uitdatabank-event-export-worker@.service':
     ensure        => $count ? {
                        0       => 'absent',
-                       default => 'file'
+                       default => 'present'
                      },
     daemon_reload => false,
     content       => template('profiles/uitdatabank/entry_api/uitdatabank-event-export-worker@.service.erb'),

--- a/manifests/uitdatabank/entry_api/mail_worker.pp
+++ b/manifests/uitdatabank/entry_api/mail_worker.pp
@@ -7,10 +7,7 @@ class profiles::uitdatabank::entry_api::mail_worker (
   realize User['www-data']
 
   systemd::unit_file { 'uitdatabank-mail-worker.service':
-    ensure        => $ensure ? {
-                       'absent'  => 'absent',
-                       'present' => 'file'
-                     },
+    ensure        => $ensure,
     content       => template('profiles/uitdatabank/entry_api/uitdatabank-mail-worker.service.erb'),
     notify        => Service['uitdatabank-mail-worker']
   }

--- a/manifests/uitpas/api/deployment.pp
+++ b/manifests/uitpas/api/deployment.pp
@@ -53,9 +53,9 @@ class profiles::uitpas::api::deployment (
 
   profiles::systemd::service_watchdog { 'uitpas':
     ensure                 => $service_watchdog ? {
-      true  => 'present',
-      false => 'absent'
-    },
+                                true  => 'present',
+                                false => 'absent'
+                              },
     check_interval_seconds => $healthcheck_interval_seconds,
     timeout_seconds        => $healthcheck_timeout_seconds,
     initial_wait_seconds   => $healthcheck_initial_wait_seconds,

--- a/manifests/uitpas/soap.pp
+++ b/manifests/uitpas/soap.pp
@@ -1,29 +1,29 @@
 class profiles::uitpas::soap (
-
   Boolean $deployment            = true,
   Boolean $magda_cert_generation = false,
   Boolean $fidus_cert_generation = false,
-  Hash $env_settings             = {},
-
+  Hash    $env_settings          = {}
 ) inherits profiles {
+
   include profiles::java
 
-  if ($magda_cert_generation) {
+  if $magda_cert_generation {
     include profiles::uitpas::soap::magda
 
-    if ($deployment) {
+    if $deployment {
       Class['profiles::uitpas::soap::magda'] ~> Class['profiles::uitpas::soap::deployment']
     }
   }
-  if ($fidus_cert_generation) {
+
+  if $fidus_cert_generation {
     include profiles::uitpas::soap::fidus
 
-    if ($deployment) {
+    if $deployment {
       Class['profiles::uitpas::soap::fidus'] ~> Class['profiles::uitpas::soap::deployment']
     }
   }
 
-  if ($deployment) {
+  if $deployment {
     include profiles::uitpas::soap::deployment
   }
 }

--- a/manifests/uitpas/soap/deployment.pp
+++ b/manifests/uitpas/soap/deployment.pp
@@ -1,25 +1,27 @@
 class profiles::uitpas::soap::deployment (
-  String $repository             = 'uitpas-soap',
-  String $version                = 'latest',
-  Hash $env_settings             = {},
+  String $repository = 'uitpas-soap',
+  String $version    = 'latest',
+  Hash $env_settings = {}
+) inherits ::profiles {
 
-) inherits profiles {
   realize Apt::Source[$repository]
 
   package { 'uitpas-soap':
     ensure  => $version,
     require => Apt::Source[$repository],
-    notify  => Service['uitpas-soap'],
+    notify  => Service['uitpas-soap']
   }
-   file { '/opt/uitpas-soap/env.properties':
-      ensure  => 'file',
-      content => template('profiles/uitpas/soap/env.properties.erb'),
-      owner   => 'glassfish',
-      group   => 'glassfish',
-      mode    => '0644'    }
+
+  file { '/opt/uitpas-soap/env.properties':
+    ensure  => 'file',
+    content => template('profiles/uitpas/soap/env.properties.erb'),
+    owner   => 'glassfish',
+    group   => 'glassfish',
+    mode    => '0644'
+  }
 
   systemd::unit_file { 'uitpas-soap.service':
-    ensure  => 'file',
+    ensure  => 'present',
     content => template('profiles/uitpas/soap/soap.service.erb')
   }
 

--- a/spec/classes/aptly_spec.rb
+++ b/spec/classes/aptly_spec.rb
@@ -43,6 +43,12 @@ describe 'profiles::aptly' do
         it { is_expected.not_to contain_profiles__lvm__mount('aptlydata') }
         it { is_expected.not_to contain_mount('/var/aptly') }
 
+        it { is_expected.to contain_file('/var/aptly').with(
+          'ensure' => 'directory',
+          'owner'  => 'aptly',
+          'group'  => 'aptly'
+        ) }
+
         it { is_expected.to contain_class('aptly').with(
           'package_ensure'       => 'latest',
           'repo'                 => false,
@@ -83,6 +89,10 @@ describe 'profiles::aptly' do
           'path'   => '/usr/local/sbin/restore-versions',
           'mode'   => '0755'
         ) }
+
+        it { is_expected.to contain_file('/var/aptly').that_requires('Group[aptly]') }
+        it { is_expected.to contain_file('/var/aptly').that_requires('User[aptly]') }
+        it { is_expected.to contain_file('/var/aptly').that_comes_before('Class[aptly]') }
 
         it { is_expected.to contain_class('aptly').that_requires('User[aptly]') }
         it { is_expected.to contain_class('aptly').that_requires('Apt::Source[aptly]') }
@@ -129,6 +139,8 @@ describe 'profiles::aptly' do
 
           context "with volume_group myvg present" do
             let(:pre_condition) { 'volume_group { "myvg": ensure => "present" }' }
+
+            it { is_expected.not_to contain_file('/var/aptly') }
 
             it { is_expected.to contain_profiles__lvm__mount('aptlydata').with(
               'volume_group' => 'myvg',

--- a/spec/classes/aptly_spec.rb
+++ b/spec/classes/aptly_spec.rb
@@ -49,7 +49,7 @@ describe 'profiles::aptly' do
           'user'                 => 'aptly',
           'config'               => {
                                       'rootDir'            => '/var/aptly',
-                                      'architectures'      => 'amd64',
+                                      'architectures'      => ['amd64'],
                                       'S3PublishEndpoints' => {}
                                     }
         ) }
@@ -159,7 +159,7 @@ describe 'profiles::aptly' do
               'user'                 => 'aptly',
               'config'               => {
                                           'rootDir'            => '/var/aptly',
-                                          'architectures'      => 'amd64',
+                                          'architectures'      => ['amd64'],
                                           'S3PublishEndpoints' => {}
                                         }
             ) }
@@ -313,7 +313,7 @@ describe 'profiles::aptly' do
               'user'                 => 'aptly',
               'config'               => {
                                           'rootDir'            => '/var/aptly',
-                                          'architectures'      => 'amd64',
+                                          'architectures'      => ['amd64'],
                                           'S3PublishEndpoints' => {
                                             'apt1' => {
                                               'region'             => 'eu-west-1',

--- a/spec/classes/aptly_spec.rb
+++ b/spec/classes/aptly_spec.rb
@@ -9,7 +9,7 @@ describe 'profiles::aptly' do
 
       context "with api_hostname => aptly.example.com and gpg_passphrase => secret" do
         let(:params) { {
-          'api_hostname' => 'aptly.example.com',
+          'api_hostname'   => 'aptly.example.com',
           'gpg_passphrase' => 'secret'
         } }
 
@@ -44,19 +44,21 @@ describe 'profiles::aptly' do
         it { is_expected.not_to contain_mount('/var/aptly') }
 
         it { is_expected.to contain_class('aptly').with(
-          'version'              => 'latest',
-          'install_repo'         => false,
-          'manage_user'          => false,
+          'package_ensure'       => 'latest',
+          'repo'                 => false,
           'user'                 => 'aptly',
-          'group'                => 'aptly',
-          'root_dir'             => '/var/aptly',
-          'enable_service'       => false,
-          'enable_api'           => true,
-          'api_bind'             => '127.0.0.1',
-          'api_port'             => '8081',
-          'api_nolock'           => true,
-          'architectures'        => ['amd64'],
-          's3_publish_endpoints' => {}
+          'config'               => {
+                                      'rootDir'            => '/var/aptly',
+                                      'architectures'      => 'amd64',
+                                      'S3PublishEndpoints' => {}
+                                    }
+        ) }
+
+        it { is_expected.to contain_class('aptly::api').with(
+          'user'                => 'aptly',
+          'group'               => 'aptly',
+          'listen'              => '127.0.0.1:8081',
+          'enable_cli_and_http' => true
         ) }
 
         it { is_expected.to_not contain_profiles__apache__vhost__redirect('http://foobar.example.com') }
@@ -74,11 +76,6 @@ describe 'profiles::aptly' do
           'minute'      => '0'
         ) }
 
-        it { is_expected.to contain_systemd__unit_file('aptly-api.service').with(
-          'enable' => true,
-          'active' => true
-        ) }
-
         it { is_expected.not_to contain_file('aptly trustedkeys.gpg') }
 
         it { is_expected.to contain_file('version restore script').with(
@@ -87,15 +84,14 @@ describe 'profiles::aptly' do
           'mode'   => '0755'
         ) }
 
-        it { is_expected.to contain_systemd__unit_file('aptly-api.service').with_content(/WorkingDirectory=\/var\/aptly/) }
-        it { is_expected.to contain_systemd__unit_file('aptly-api.service').with_content(/ExecStart=\/usr\/bin\/aptly api serve -listen=127.0.0.1:8081 -no-lock/) }
-
-        it { is_expected.to contain_systemd__unit_file('aptly-api.service').that_requires('Class[aptly]') }
-
         it { is_expected.to contain_class('aptly').that_requires('User[aptly]') }
+        it { is_expected.to contain_class('aptly').that_requires('Apt::Source[aptly]') }
+
+        it { is_expected.to contain_class('aptly::api').that_requires('Class[aptly]') }
+        it { is_expected.to contain_class('aptly::api').that_requires('User[aptly]') }
+        it { is_expected.to contain_class('aptly::api').that_requires('Group[aptly]') }
 
         it { is_expected.to contain_apt__key('aptly').that_comes_before('Apt::Source[aptly]') }
-        it { is_expected.to contain_class('aptly').that_requires('Apt::Source[aptly]') }
 
         it { is_expected.to contain_cron('aptly db cleanup daily').that_requires('Class[aptly]') }
         it { is_expected.to contain_cron('aptly db cleanup daily').that_requires('User[aptly]') }
@@ -116,7 +112,7 @@ describe 'profiles::aptly' do
               'version'      => '1.2.3',
               'api_bind'     => '1.2.3.4',
               'api_port'     => 8080,
-              'repositories' => {'foo' => { 'archive' => false }, 'bar' => { 'archive' => true }},
+              'repositories' => { 'foo' => { 'archive' => false }, 'bar' => { 'archive' => true } },
               'lvm'          => true,
               'volume_group' => 'myvg',
               'volume_size'  => '10G',
@@ -159,10 +155,20 @@ describe 'profiles::aptly' do
             ) }
 
             it { is_expected.to contain_class('aptly').with(
-              'version'  => '1.2.3',
-              'root_dir' => '/var/aptly',
-              'api_bind' => '1.2.3.4',
-              'api_port' => 8080
+              'package_ensure'       => '1.2.3',
+              'user'                 => 'aptly',
+              'config'               => {
+                                          'rootDir'            => '/var/aptly',
+                                          'architectures'      => 'amd64',
+                                          'S3PublishEndpoints' => {}
+                                        }
+            ) }
+
+            it { is_expected.to contain_class('aptly::api').with(
+              'user'                => 'aptly',
+              'group'               => 'aptly',
+              'listen'              => '1.2.3.4:8080',
+              'enable_cli_and_http' => true
             ) }
 
             it { is_expected.to contain_profiles__apache__vhost__redirect('http://foobar.example.com').with(
@@ -176,17 +182,17 @@ describe 'profiles::aptly' do
             ) }
 
             it { is_expected.to contain_aptly__repo('foo').with(
-              'default_component' => 'main'
+              'component' => 'main'
             ) }
 
             it { is_expected.not_to contain_aptly__repo('foo-archive') }
 
             it { is_expected.to contain_aptly__repo('bar').with(
-              'default_component' => 'main'
+              'component' => 'main'
             ) }
 
             it { is_expected.to contain_aptly__repo('bar-archive').with(
-              'default_component' => 'main'
+              'component' => 'main'
             ) }
 
             it { is_expected.to contain_file('aptly trustedkeys.gpg').with(
@@ -199,10 +205,9 @@ describe 'profiles::aptly' do
 
             it { is_expected.to contain_aptly__mirror('mymirror').with(
               'location'      => 'http://mymirror.example.com',
-              'distribution'  => 'unstable',
-              'components'    => ['main', 'contrib'],
+              'release'       => 'unstable',
+              'repos'         => ['main', 'contrib'],
               'architectures' => ['amd64'],
-              'update'        => false,
               'keyring'       => '/home/aptly/.gnupg/trustedkeys.gpg'
             ) }
 
@@ -243,13 +248,13 @@ describe 'profiles::aptly' do
               'volume_size'       => '100G',
               'publish_endpoints' => {
                  'apt1' => {
-                   'region' => 'eu-west-1',
-                   'bucket' => 'apt1',
-                   'awsAccessKeyID' => '123',
+                   'region'             => 'eu-west-1',
+                   'bucket'             => 'apt1',
+                   'awsAccessKeyID'     => '123',
                    'awsSecretAccessKey' => 'abc'
                  }
               },
-              'repositories'      => {'baz' => {} },
+              'repositories'      => { 'baz' => {} },
               'mirrors'           => { 'mirror1' => {
                                                       'location'      => 'http://mirror1.example.com' ,
                                                       'distribution'  => 'testing',
@@ -304,17 +309,24 @@ describe 'profiles::aptly' do
             ) }
 
             it { is_expected.to contain_class('aptly').with(
-              's3_publish_endpoints' => { 'apt1' => {
-                                            'region' => 'eu-west-1',
-                                            'bucket' => 'apt1',
-                                            'awsAccessKeyID' => '123',
-                                            'awsSecretAccessKey' => 'abc'
+              'package_ensure'       => 'latest',
+              'user'                 => 'aptly',
+              'config'               => {
+                                          'rootDir'            => '/var/aptly',
+                                          'architectures'      => 'amd64',
+                                          'S3PublishEndpoints' => {
+                                            'apt1' => {
+                                              'region'             => 'eu-west-1',
+                                              'bucket'             => 'apt1',
+                                              'awsAccessKeyID'     => '123',
+                                              'awsSecretAccessKey' => 'abc'
+                                            }
                                           }
                                         }
             ) }
 
             it { is_expected.to contain_aptly__repo('baz').with(
-              'default_component' => 'main'
+              'component' => 'main'
             ) }
 
             it { is_expected.not_to contain_aptly__repo('baz-archive') }
@@ -329,19 +341,17 @@ describe 'profiles::aptly' do
 
             it { is_expected.to contain_aptly__mirror('mirror1').with(
               'location'      => 'http://mirror1.example.com',
-              'distribution'  => 'testing',
-              'components'    => ['nonfree'],
+              'release'       => 'testing',
+              'repos'         => ['nonfree'],
               'architectures' => ['arm64', 'amd64'],
-              'update'        => false,
               'keyring'       => '/home/aptly/.gnupg/trustedkeys.gpg'
             ) }
 
             it { is_expected.to contain_aptly__mirror('mirror2').with(
               'location'      => 'http://mirror2.example.com',
-              'distribution'  => 'stable',
-              'components'    => ['bar', 'baz'],
+              'release'       => 'stable',
+              'repos'         => ['bar', 'baz'],
               'architectures' => ['arm64'],
-              'update'        => false,
               'keyring'       => '/home/aptly/.gnupg/trustedkeys.gpg'
             ) }
 

--- a/spec/classes/firewall/rules_spec.rb
+++ b/spec/classes/firewall/rules_spec.rb
@@ -11,81 +11,81 @@ describe 'profiles::firewall::rules' do
         it { is_expected.to compile.with_all_deps }
 
         it { is_expected.to contain_firewall('100 accept SSH traffic').with(
-          'proto'  => 'tcp',
-          'dport'  => '22',
-          'action' => 'accept'
+          'proto' => 'tcp',
+          'dport' => '22',
+          'jump'  => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('300 accept HTTP traffic').with(
-          'proto'  => 'tcp',
-          'dport'  => '80',
-          'action' => 'accept'
+          'proto' => 'tcp',
+          'dport' => '80',
+          'jump'  => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('300 accept HTTPS traffic').with(
-          'proto'  => 'tcp',
-          'dport'  => '443',
-          'action' => 'accept'
+          'proto' => 'tcp',
+          'dport' => '443',
+          'jump'  => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('300 accept SMTP traffic').with(
-          'proto'  => 'tcp',
-          'dport'  => '25',
-          'action' => 'accept'
+          'proto' => 'tcp',
+          'dport' => '25',
+          'jump'  => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('300 accept puppetserver HTTPS traffic').with(
-          'proto'  => 'tcp',
-          'dport'  => '8140',
-          'action' => 'accept'
+          'proto' => 'tcp',
+          'dport' => '8140',
+          'jump'  => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('300 accept puppetdb HTTPS traffic').with(
-          'proto'  => 'tcp',
-          'dport'  => '8081',
-          'action' => 'accept'
+          'proto' => 'tcp',
+          'dport' => '8081',
+          'jump'  => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('400 accept redis traffic').with(
-          'proto'  => 'tcp',
-          'dport'  => '6379',
-          'action' => 'accept'
+          'proto' => 'tcp',
+          'dport' => '6379',
+          'jump'  => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('400 accept meilisearch traffic').with(
-          'proto'  => 'tcp',
-          'dport'  => '7700',
-          'action' => 'accept'
+          'proto' => 'tcp',
+          'dport' => '7700',
+          'jump'  => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('400 accept mysql traffic').with(
-          'proto'  => 'tcp',
-          'dport'  => '3306',
-          'action' => 'accept'
+          'proto' => 'tcp',
+          'dport' => '3306',
+          'jump'  => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('400 accept vault traffic').with(
-          'proto'  => 'tcp',
-          'dport'  => '8200',
-          'action' => 'accept'
+          'proto' => 'tcp',
+          'dport' => '8200',
+          'jump'  => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('400 accept mongodb traffic').with(
-          'proto'  => 'tcp',
-          'dport'  => '27017',
-          'action' => 'accept'
+          'proto' => 'tcp',
+          'dport' => '27017',
+          'jump'  => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('400 accept mailpit SMTP traffic').with(
-          'proto'  => 'tcp',
-          'dport'  => '1025',
-          'action' => 'accept'
+          'proto' => 'tcp',
+          'dport' => '1025',
+          'jump'  => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('400 accept logstash filebeat traffic').with(
-          'proto'  => 'tcp',
-          'dport'  => '5000',
-          'action' => 'accept'
+          'proto' => 'tcp',
+          'dport' => '5000',
+          'jump'  => 'accept'
         ) }
       end
     end

--- a/spec/classes/firewall_spec.rb
+++ b/spec/classes/firewall_spec.rb
@@ -21,32 +21,32 @@ describe 'profiles::firewall' do
         ) }
 
         it { is_expected.to contain_firewall('000 accept all ICMP traffic').with(
-          'proto'  => 'icmp',
-          'action' => 'accept'
+          'proto' => 'icmp',
+          'jump'  => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('001 accept all traffic to lo interface').with(
           'proto'   => 'all',
           'iniface' => 'lo',
-          'action'  => 'accept'
+          'jump'    => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('002 reject local traffic not on loopback interface').with(
           'proto'       => 'all',
           'iniface'     => '! lo',
           'destination' => '127.0.0.0/8',
-          'action'      => 'reject'
+          'jump'        => 'reject'
         ) }
 
         it { is_expected.to contain_firewall('003 accept related established rules').with(
-          'proto'  => 'all',
-          'state'  => ['RELATED', 'ESTABLISHED'],
-          'action' => 'accept'
+          'proto' => 'all',
+          'state' => ['RELATED', 'ESTABLISHED'],
+          'jump'  => 'accept'
         ) }
 
         it { is_expected.to contain_firewall('999 drop all').with(
           'proto'  => 'all',
-          'action' => 'drop',
+          'jump'   => 'drop',
           'before' => nil
         ) }
       end

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -67,11 +67,7 @@ describe 'profiles::postfix' do
 
           it { is_expected.to contain_concat('/etc/postfix/mynetworks') }
 
-          it { is_expected.to contain_firewall('300 accept SMTP traffic').with(
-            'proto'  => 'tcp',
-            'dport'  => '25',
-            'action' => 'accept'
-          ) }
+          it { is_expected.to contain_firewall('300 accept SMTP traffic') }
 
           it { is_expected.to contain_concat('/etc/postfix/mynetworks').that_requires('File[/etc/postfix]') }
           it { is_expected.to contain_concat('/etc/postfix/mynetworks').that_notifies('Class[postfix::server]') }
@@ -108,11 +104,7 @@ describe 'profiles::postfix' do
 
           it { is_expected.to contain_concat('/etc/postfix/mynetworks') }
 
-          it { is_expected.to contain_firewall('300 accept SMTP traffic').with(
-            'proto' => 'tcp',
-            'dport' => '25',
-            'action' => 'accept'
-          ) }
+          it { is_expected.to contain_firewall('300 accept SMTP traffic') }
 
           it { is_expected.to contain_concat('/etc/postfix/mynetworks').that_requires('File[/etc/postfix]') }
           it { is_expected.to contain_concat('/etc/postfix/mynetworks').that_notifies('Class[postfix::server]') }
@@ -270,11 +262,7 @@ describe 'profiles::postfix' do
 
           it { is_expected.to contain_concat('/etc/postfix/mynetworks') }
 
-          it { is_expected.to contain_firewall('300 accept SMTP traffic').with(
-            'proto'  => 'tcp',
-            'dport'  => '25',
-            'action' => 'accept'
-          ) }
+          it { is_expected.to contain_firewall('300 accept SMTP traffic') }
 
           it { is_expected.to contain_concat('/etc/postfix/mynetworks').that_requires('File[/etc/postfix]') }
           it { is_expected.to contain_concat('/etc/postfix/mynetworks').that_notifies('Class[postfix::server]') }
@@ -309,11 +297,7 @@ describe 'profiles::postfix' do
               'tag'     => 'postfix_mynetworks'
             ) }
 
-            it { is_expected.to contain_firewall('300 accept SMTP traffic').with(
-              'proto'  => 'tcp',
-              'dport'  => '25',
-              'action' => 'accept'
-            ) }
+            it { is_expected.to contain_firewall('300 accept SMTP traffic') }
           end
 
           context "with aliases_source => puppet:///private/postfix/virtual" do

--- a/spec/classes/projectaanvraag/api/amqp_consumer_spec.rb
+++ b/spec/classes/projectaanvraag/api/amqp_consumer_spec.rb
@@ -19,7 +19,7 @@ describe 'profiles::projectaanvraag::api::amqp_consumer' do
         it { is_expected.to contain_user('www-data') }
 
         it { is_expected.to contain_systemd__unit_file('projectaanvraag-api-amqp-consumer.service').with(
-          'ensure' => 'file'
+          'ensure' => 'present'
         ) }
 
         it { is_expected.to contain_systemd__unit_file('projectaanvraag-api-amqp-consumer.service').with_content(/WorkingDirectory=\/var\/www\/projectaanvraag-api/) }

--- a/spec/classes/ssh_spec.rb
+++ b/spec/classes/ssh_spec.rb
@@ -44,11 +44,7 @@ describe 'profiles::ssh' do
           'purge' => true
         ) }
 
-        it { is_expected.to contain_firewall('100 accept SSH traffic').with(
-          'proto'  => 'tcp',
-          'dport'  => '22',
-          'action' => 'accept'
-        ) }
+        it { is_expected.to contain_firewall('100 accept SSH traffic') }
 
         it { is_expected.to have_ssh_authorized_key_resource_count(0) }
 

--- a/spec/classes/uitdatabank/entry_api/amqp_listener_uitpas_spec.rb
+++ b/spec/classes/uitdatabank/entry_api/amqp_listener_uitpas_spec.rb
@@ -19,7 +19,7 @@ describe 'profiles::uitdatabank::entry_api::amqp_listener_uitpas' do
         it { is_expected.to contain_user('www-data') }
 
         it { is_expected.to contain_systemd__unit_file('uitdatabank-amqp-listener-uitpas.service').with(
-          'ensure' => 'file'
+          'ensure' => 'present'
         ) }
 
         it { is_expected.to contain_systemd__unit_file('uitdatabank-amqp-listener-uitpas.service').with_content(/WorkingDirectory=\/var\/www\/udb3-backend/) }

--- a/spec/classes/uitdatabank/entry_api/bulk_label_offer_worker_spec.rb
+++ b/spec/classes/uitdatabank/entry_api/bulk_label_offer_worker_spec.rb
@@ -19,7 +19,7 @@ describe 'profiles::uitdatabank::entry_api::bulk_label_offer_worker' do
         it { is_expected.to contain_user('www-data') }
 
         it { is_expected.to contain_systemd__unit_file('uitdatabank-bulk-label-offer-worker.service').with(
-          'ensure' => 'file'
+          'ensure' => 'present'
         ) }
 
         it { is_expected.to contain_systemd__unit_file('uitdatabank-bulk-label-offer-worker.service').with_content(/WorkingDirectory=\/var\/www\/udb3-backend/) }

--- a/spec/classes/uitdatabank/entry_api/event_export_workers_spec.rb
+++ b/spec/classes/uitdatabank/entry_api/event_export_workers_spec.rb
@@ -20,6 +20,7 @@ describe 'profiles::uitdatabank::entry_api::event_export_workers' do
         it { is_expected.to contain_file('/etc/puppetlabs/facter/facts.d') }
 
         it { is_expected.to contain_systemd__unit_file('uitdatabank-event-export-worker@.service').with(
+          'ensure'        => 'present',
           'daemon_reload' => false
         ) }
 

--- a/spec/classes/uitdatabank/entry_api/mail_worker_spec.rb
+++ b/spec/classes/uitdatabank/entry_api/mail_worker_spec.rb
@@ -19,7 +19,7 @@ describe 'profiles::uitdatabank::entry_api::mail_worker' do
         it { is_expected.to contain_user('www-data') }
 
         it { is_expected.to contain_systemd__unit_file('uitdatabank-mail-worker.service').with(
-          'ensure' => 'file'
+          'ensure' => 'present'
         ) }
 
         it { is_expected.to contain_systemd__unit_file('uitdatabank-mail-worker.service').with_content(/WorkingDirectory=\/var\/www\/udb3-backend/) }

--- a/spec/defines/glassfish/domain_spec.rb
+++ b/spec/defines/glassfish/domain_spec.rb
@@ -53,15 +53,15 @@ describe 'profiles::glassfish::domain' do
             ) }
 
             it { is_expected.to contain_firewall('400 accept glassfish domain foobar-api HTTP traffic').with(
-              'proto'  => 'tcp',
-              'dport'  => '4880',
-              'action' => 'accept'
+              'proto' => 'tcp',
+              'dport' => '4880',
+              'jump'  => 'accept'
             ) }
 
             it { is_expected.to contain_firewall('400 accept glassfish domain foobar-api HTTPS traffic').with(
-              'proto'  => 'tcp',
-              'dport'  => '4881',
-              'action' => 'accept'
+              'proto' => 'tcp',
+              'dport' => '4881',
+              'jump'  => 'accept'
             ) }
 
             it { is_expected.to contain_profiles__glassfish__domain__service('foobar-api').with(
@@ -158,15 +158,15 @@ describe 'profiles::glassfish::domain' do
             ) }
 
             it { is_expected.to contain_firewall('400 accept glassfish domain foobar-api HTTP traffic').with(
-              'proto'  => 'tcp',
-              'dport'  => '14880',
-              'action' => 'accept'
+              'proto' => 'tcp',
+              'dport' => '14880',
+              'jump'  => 'accept'
             ) }
 
             it { is_expected.to contain_firewall('400 accept glassfish domain foobar-api HTTPS traffic').with(
-              'proto'  => 'tcp',
-              'dport'  => '14881',
-              'action' => 'accept'
+              'proto' => 'tcp',
+              'dport' => '14881',
+              'jump'  => 'accept'
             ) }
 
             it { is_expected.to contain_profiles__glassfish__domain__service('foobar-api').with(

--- a/spec/defines/systemd/service_watchdog_spec.rb
+++ b/spec/defines/systemd/service_watchdog_spec.rb
@@ -62,10 +62,10 @@ describe 'profiles::systemd::service_watchdog' do
 
         context 'with service => bar, timeout_seconds => 15, initial_wait_seconds => 20 and healthcheck => test -f /tmp/watchdog_file_present' do
           let(:params) { {
-            'service'         => 'bar',
-            'timeout_seconds' => 15,
+            'service'              => 'bar',
+            'timeout_seconds'      => 15,
             'initial_wait_seconds' => 20,
-            'healthcheck'     => 'test -f /tmp/watchdog_file_present'
+            'healthcheck'          => 'test -f /tmp/watchdog_file_present'
           } }
 
           it { is_expected.to contain_file('foo-watchdog').with_content(/CHECK_INTERVAL_SECONDS=3/) }

--- a/spec/defines/systemd/service_watchdog_spec.rb
+++ b/spec/defines/systemd/service_watchdog_spec.rb
@@ -31,7 +31,7 @@ describe 'profiles::systemd::service_watchdog' do
           it { is_expected.to contain_file('foo-watchdog').with_content(/\/usr\/bin\/true/) }
 
           it { is_expected.to contain_systemd__unit_file('foo-watchdog.service').with(
-            'ensure' => 'file'
+            'ensure' => 'present'
           ) }
 
           it { is_expected.to contain_systemd__unit_file('foo-watchdog.service').with_content(/Description=Watchdog service for foo/) }


### PR DESCRIPTION
* Update stdlib module to 9.x (`.fixtures.yml`)
* Switch the aptly module to voxpupuli-aptly and adapt the aptly profile accordingly (`.fixtures.yaml`, `manifests/aptly.pp` and `spec/classes/aptly_spec.rb`)
* Update all puppet modules to a version compatible with stdlib module 9.x and fix any breaking changes required by the module updates (`.fixtures.yml`, `manifests/**/*.pp` and `spec/classes/**/*.rb`)

I made sure all the tests are successful and made an aptly setup on my vagrant box to check functionality of the new module. Will deploy to infrastructure environment by environment after approval.