### PR TITLE
Add a proxy setup for UiTPAS Balie react on /nieuw

### DIFF
--- a/manifests/uitpas/balie_api.pp
+++ b/manifests/uitpas/balie_api.pp
@@ -52,6 +52,12 @@ class profiles::uitpas::balie_api (
                              }, {
                                'comment'      => 'Proxy /app/ to React app',
                                'rewrite_rule' => "^/app/(.*)\$ ${balie_next_url}/app/\$1 [P,L]"
+                             }, {
+                               'comment'      => 'Proxy /nieuw to React app',
+                               'rewrite_rule' => "^/nieuw\$ ${balie_next_url}/nieuw [P,L]"
+                             }, {
+                               'comment'      => 'Proxy /nieuw/ to React app',
+                               'rewrite_rule' => "^/nieuw/(.*)\$ ${balie_next_url}/nieuw/\$1 [P,L]"
                              }
                            ]
   }

--- a/spec/classes/uitpas/balie_api_spec.rb
+++ b/spec/classes/uitpas/balie_api_spec.rb
@@ -62,6 +62,12 @@ describe 'profiles::uitpas::balie_api' do
                                         }, {
                                           'comment'      => 'Proxy /app/ to React app',
                                           'rewrite_rule' => '^/app/(.*)$ http://balie-next.example.com/app/$1 [P,L]'
+                                        }, {
+                                          'comment'      => 'Proxy /nieuw to React app',
+                                          'rewrite_rule' => '^/nieuw$ http://balie-next.example.com/nieuw [P,L]'
+                                        }, {
+                                          'comment'      => 'Proxy /nieuw/ to React app',
+                                          'rewrite_rule' => '^/nieuw/(.*)$ http://balie-next.example.com/nieuw/$1 [P,L]'
                                         }
                                       ]
           ) }
@@ -119,6 +125,12 @@ describe 'profiles::uitpas::balie_api' do
                                         }, {
                                           'comment'      => 'Proxy /app/ to React app',
                                           'rewrite_rule' => '^/app/(.*)$ https://next.example.com/app/$1 [P,L]'
+                                        }, {
+                                          'comment'      => 'Proxy /nieuw to React app',
+                                          'rewrite_rule' => '^/nieuw$ https://next.example.com/nieuw [P,L]'
+                                        }, {
+                                          'comment'      => 'Proxy /nieuw/ to React app',
+                                          'rewrite_rule' => '^/nieuw/(.*)$ https://next.example.com/nieuw/$1 [P,L]'
                                         }
                                       ]
           ) }


### PR DESCRIPTION
First step: adding a proxy setup for /nieuw to the React app. After testing, the /app proxy can be moved to the angular app.