### PR TITLE
[OPS-1540]: use new version of ArgoCD

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -104,7 +104,7 @@ inherits ::profiles {
   }
 
   @package { 'argocd':
-    ensure  => 'present',
+    ensure  => 'latest',
     require => Apt::Source['publiq-tools']
   }
 

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -104,7 +104,7 @@ inherits ::profiles {
   }
 
   @package { 'argocd':
-    ensure  => 'latest',
+    ensure  => !!$versions['argocd'] ? { true => $versions['argocd'], default => 'present' },
     require => Apt::Source['publiq-tools']
   }
 

--- a/spec/classes/jenkins/buildtools/extra_spec.rb
+++ b/spec/classes/jenkins/buildtools/extra_spec.rb
@@ -13,7 +13,7 @@ describe 'profiles::jenkins::buildtools::extra' do
 
       it { is_expected.to contain_package('golang').with({ 'ensure' => 'present' }) }
       it { is_expected.to contain_package('kubectl').with({ 'ensure' => 'present' }) }
-      it { is_expected.to contain_package('argocd').with({ 'latest' => 'present' }) }
+      it { is_expected.to contain_package('argocd').with({ 'ensure' => 'present' }) }
       it { is_expected.to contain_package('maven').with({ 'ensure' => 'present' }) }
 
       context 'with hieradata' do

--- a/spec/classes/jenkins/buildtools/extra_spec.rb
+++ b/spec/classes/jenkins/buildtools/extra_spec.rb
@@ -13,7 +13,7 @@ describe 'profiles::jenkins::buildtools::extra' do
 
       it { is_expected.to contain_package('golang').with({ 'ensure' => 'present' }) }
       it { is_expected.to contain_package('kubectl').with({ 'ensure' => 'present' }) }
-      it { is_expected.to contain_package('argocd').with({ 'ensure' => 'present' }) }
+      it { is_expected.to contain_package('argocd').with({ 'latest' => 'present' }) }
       it { is_expected.to contain_package('maven').with({ 'ensure' => 'present' }) }
 
       context 'with hieradata' do


### PR DESCRIPTION
I published a new package for ArgoCD (v3.4.3) in publiq-tools. However, puppet's `ensure => 'present'` wouldn't upgrade to the new version on nodes that already had the previous version installed.
Switching to `latest` should force the upgrade