### PR TITLE
UPS-6100: Add cron job for order completion

### DIFF
--- a/manifests/uitpas/api/cron.pp
+++ b/manifests/uitpas/api/cron.pp
@@ -232,4 +232,11 @@ class profiles::uitpas::api::cron (
     minute  => '45',
     *       => $cron_default_attributes,
   }
+  cron { 'uitpas orders trigger order completion':
+    ensure  => $cron_enabled ? { true => 'present', default => 'absent' },
+    command => "/usr/bin/curl '${base_url}/uitid/rest/cron/orders/trigger-order-completion' >> ${cron_logdir}/orders-trigger-order-completion.log 2>&1",
+    hour    => '*',
+    minute  => '*/5',
+    *       => $cron_default_attributes,
+  }
 }


### PR DESCRIPTION

### Added

- Configures a cron task to trigger the order completion endpoint. This job executes every five minutes.



