### PR TITLE
Add passwordless for sudogroup

### DIFF
--- a/manifests/sudo.pp
+++ b/manifests/sudo.pp
@@ -2,6 +2,12 @@ class profiles::sudo inherits ::profiles {
 
   class { '::sudo': }
 
+  sudo::conf { 'sudo-group':
+    priority => '10',
+    content  => '%sudo ALL=(ALL) NOPASSWD: ALL',
+    require  => Class['sudo']
+  }
+
   if $facts['ec2_metadata'] {
     $admin_user = 'ubuntu'
 

--- a/spec/classes/sudo_spec.rb
+++ b/spec/classes/sudo_spec.rb
@@ -21,6 +21,12 @@ describe 'profiles::sudo' do
 
         it { is_expected.to contain_class('sudo') }
 
+        it { is_expected.to contain_sudo__conf('sudo-group').with(
+          'content'  => '%sudo ALL=(ALL) NOPASSWD: ALL',
+          'priority' => '10'
+          )
+        }
+
         it { is_expected.to contain_sudo__conf('ubuntu').with(
           'content'  => 'ubuntu ALL=(ALL) NOPASSWD: ALL',
           'priority' => '10'
@@ -37,6 +43,7 @@ describe 'profiles::sudo' do
         it { is_expected.to contain_sudo__conf('ubuntu').that_requires('User[ubuntu]') }
         it { is_expected.to contain_sudo__conf('ssm-user').that_requires('Class[sudo]') }
         it { is_expected.to contain_sudo__conf('ssm-user').that_requires('User[ssm-user]') }
+        it { is_expected.to contain_sudo__conf('sudo-group').that_requires('Class[sudo]') }
       end
 
       context "not on AWS EC2" do
@@ -55,6 +62,12 @@ describe 'profiles::sudo' do
 
         it { is_expected.to contain_class('sudo') }
 
+        it { is_expected.to contain_sudo__conf('sudo-group').with(
+          'content'  => '%sudo ALL=(ALL) NOPASSWD: ALL',
+          'priority' => '10'
+          )
+        }
+
         it { is_expected.to contain_sudo__conf('vagrant').with(
           'content'  => 'vagrant ALL=(ALL) NOPASSWD: ALL',
           'priority' => '10'
@@ -63,6 +76,7 @@ describe 'profiles::sudo' do
 
         it { is_expected.to contain_sudo__conf('vagrant').that_requires('Class[sudo]') }
         it { is_expected.to contain_sudo__conf('vagrant').that_requires('User[vagrant]') }
+        it { is_expected.to contain_sudo__conf('sudo-group').that_requires('Class[sudo]') }
       end
     end
   end


### PR DESCRIPTION
This pull request updates the `sudo` Puppet manifest and its corresponding tests to ensure all members of the `sudo` group have passwordless sudo access. The main change is the addition of a new `sudo::conf` resource for the `sudo` group, along with tests to verify its configuration and dependencies.

Configuration changes:

* Added a `sudo::conf` resource named `sudo-group` in `manifests/sudo.pp` to grant passwordless sudo to all users in the `sudo` group (`%sudo ALL=(ALL) NOPASSWD: ALL`).

Testing improvements:

* Updated `spec/classes/sudo_spec.rb` to test that the `sudo-group` config is created with the correct content and priority. [[1]](diffhunk://#diff-0f2174cec0f2d46f2ec2bef9fdcc580350abc268ddcfec75ed13ddc096479fb2R24-R29) [[2]](diffhunk://#diff-0f2174cec0f2d46f2ec2bef9fdcc580350abc268ddcfec75ed13ddc096479fb2R65-R70)
* Added tests to verify that the `sudo-group` config requires the `sudo` class, ensuring proper resource ordering. [[1]](diffhunk://#diff-0f2174cec0f2d46f2ec2bef9fdcc580350abc268ddcfec75ed13ddc096479fb2R46) [[2]](diffhunk://#diff-0f2174cec0f2d46f2ec2bef9fdcc580350abc268ddcfec75ed13ddc096479fb2R79)