### PR TITLE
Use regional S3 endpoint for Terraform hieradata

### DIFF
--- a/manifests/puppet/puppetserver/terraform.pp
+++ b/manifests/puppet/puppetserver/terraform.pp
@@ -1,6 +1,7 @@
 class profiles::puppet::puppetserver::terraform (
   String  $bucket,
-  Boolean $use_iam_role = true
+  Boolean $use_iam_role = true,
+  String  $aws_region   = 'eu-west-1'
 ) inherits ::profiles {
 
   $iam_role_mount_option = $use_iam_role ? {
@@ -8,7 +9,7 @@ class profiles::puppet::puppetserver::terraform (
     false => undef
   }
 
-  $mount_options = ['_netdev', 'nonempty', 'ro', 'nosuid', 'allow_other', 'multireq_max=5', 'uid=452', 'gid=452', 'endpoint=eu-west-1', 'url=https://s3.eu-west-1.amazonaws.com', $iam_role_mount_option]
+  $mount_options = ['_netdev', 'nonempty', 'ro', 'nosuid', 'allow_other', 'multireq_max=5', 'uid=452', 'gid=452', "endpoint=${aws_region}", "url=https://s3.${aws_region}.amazonaws.com", $iam_role_mount_option]
 
   realize Group['puppet']
   realize User['puppet']

--- a/manifests/puppet/puppetserver/terraform.pp
+++ b/manifests/puppet/puppetserver/terraform.pp
@@ -8,7 +8,7 @@ class profiles::puppet::puppetserver::terraform (
     false => undef
   }
 
-  $mount_options = ['_netdev', 'nonempty', 'ro', 'nosuid', 'allow_other', 'multireq_max=5', 'uid=452', 'gid=452', $iam_role_mount_option]
+  $mount_options = ['_netdev', 'nonempty', 'ro', 'nosuid', 'allow_other', 'multireq_max=5', 'uid=452', 'gid=452', 'endpoint=eu-west-1', 'url=https://s3.eu-west-1.amazonaws.com', $iam_role_mount_option]
 
   realize Group['puppet']
   realize User['puppet']

--- a/spec/classes/puppet/puppetserver/terraform_spec.rb
+++ b/spec/classes/puppet/puppetserver/terraform_spec.rb
@@ -14,7 +14,8 @@ describe 'profiles::puppet::puppetserver::terraform' do
 
         it { is_expected.to contain_class('profiles::puppet::puppetserver::terraform').with(
           'bucket'       => 'mybucket',
-          'use_iam_role' => true
+          'use_iam_role' => true,
+          'aws_region'   => 'eu-west-1'
         ) }
 
         it { is_expected.to contain_group('puppet') }
@@ -44,10 +45,11 @@ describe 'profiles::puppet::puppetserver::terraform' do
         it { is_expected.to contain_class('profiles::s3fs').that_comes_before('Mount[puppetserver-terraform-data]') }
       end
 
-      context "with bucket => foobar and use_iam_role => false" do
+      context "with bucket => foobar, use_iam_role => false and aws_region => eu-central-1" do
         let(:params) { {
           'bucket'       => 'foobar',
-          'use_iam_role' => false
+          'use_iam_role' => false,
+          'aws_region'   => 'eu-central-1'
         } }
 
         it { is_expected.to contain_mount('puppetserver-terraform-data').with(
@@ -55,7 +57,7 @@ describe 'profiles::puppet::puppetserver::terraform' do
           'name'     => '/etc/puppetlabs/code/data/terraform',
           'device'   => 'foobar',
           'fstype'   => 'fuse.s3fs',
-          'options'  => '_netdev,nonempty,ro,nosuid,allow_other,multireq_max=5,uid=452,gid=452,endpoint=eu-west-1,url=https://s3.eu-west-1.amazonaws.com',
+          'options'  => '_netdev,nonempty,ro,nosuid,allow_other,multireq_max=5,uid=452,gid=452,endpoint=eu-central-1,url=https://s3.eu-central-1.amazonaws.com',
           'remounts' => false,
           'atboot'   => true
         ) }

--- a/spec/classes/puppet/puppetserver/terraform_spec.rb
+++ b/spec/classes/puppet/puppetserver/terraform_spec.rb
@@ -33,7 +33,7 @@ describe 'profiles::puppet::puppetserver::terraform' do
           'name'     => '/etc/puppetlabs/code/data/terraform',
           'device'   => 'mybucket',
           'fstype'   => 'fuse.s3fs',
-          'options'  => '_netdev,nonempty,ro,nosuid,allow_other,multireq_max=5,uid=452,gid=452,iam_role=auto',
+          'options'  => '_netdev,nonempty,ro,nosuid,allow_other,multireq_max=5,uid=452,gid=452,endpoint=eu-west-1,url=https://s3.eu-west-1.amazonaws.com,iam_role=auto',
           'remounts' => false,
           'atboot'   => true
         ) }
@@ -55,7 +55,7 @@ describe 'profiles::puppet::puppetserver::terraform' do
           'name'     => '/etc/puppetlabs/code/data/terraform',
           'device'   => 'foobar',
           'fstype'   => 'fuse.s3fs',
-          'options'  => '_netdev,nonempty,ro,nosuid,allow_other,multireq_max=5,uid=452,gid=452',
+          'options'  => '_netdev,nonempty,ro,nosuid,allow_other,multireq_max=5,uid=452,gid=452,endpoint=eu-west-1,url=https://s3.eu-west-1.amazonaws.com',
           'remounts' => false,
           'atboot'   => true
         ) }


### PR DESCRIPTION
## Summary

  Configure the Puppetserver Terraform hieradata s3fs mount to use the regional eu-west-1
  S3 endpoint.

  ## Changes

  - Add endpoint=eu-west-1 to the s3fs mount options.
  - Add url=https://s3.eu-west-1.amazonaws.com to the s3fs mount options.
  - Update the focused Puppet profile specs.

  ## Why

  The new publiq-configdata bucket cannot be mounted reliably through the default global
  S3 endpoint. Using the regional endpoint prevents misleading signature and credential
  errors.