### PR TITLE
Add MFA dir mount for puppet webserver

### DIFF
--- a/manifests/puppet/puppetserver.pp
+++ b/manifests/puppet/puppetserver.pp
@@ -16,6 +16,9 @@ class profiles::puppet::puppetserver (
   Boolean                                  $terraform_integration  = lookup('data::puppet::terraform_integration', Boolean, 'first', false),
   Optional[String]                         $terraform_bucket       = undef,
   Boolean                                  $terraform_use_iam_role = true,
+  Optional[String]                         $mfa_bucket             = undef,
+  Boolean                                  $mfa_use_iam_role       = true,
+  String                                   $mfa_aws_region         = 'eu-west-1',
   Optional[Stdlib::Httpurl]                $puppetdb_url           = undef,
   Optional[String]                         $puppetdb_version       = undef,
   Optional[String]                         $initial_heap_size      = undef,
@@ -138,6 +141,15 @@ class profiles::puppet::puppetserver (
       bucket       => $terraform_bucket,
       use_iam_role => $terraform_use_iam_role,
       require      => Class['profiles::puppet::puppetserver::hiera'],
+      notify       => Class['profiles::puppet::puppetserver::service'],
+    }
+  }
+
+  if $mfa_bucket {
+    class { 'profiles::puppet::puppetserver::mfa':
+      bucket       => $mfa_bucket,
+      use_iam_role => $mfa_use_iam_role,
+      aws_region   => $mfa_aws_region,
       notify       => Class['profiles::puppet::puppetserver::service'],
     }
   }

--- a/manifests/puppet/puppetserver/mfa.pp
+++ b/manifests/puppet/puppetserver/mfa.pp
@@ -1,0 +1,37 @@
+class profiles::puppet::puppetserver::mfa (
+  String  $bucket,
+  Boolean $use_iam_role = true,
+  String  $aws_region   = 'eu-west-1'
+) inherits ::profiles {
+
+  $iam_role_mount_option = $use_iam_role ? {
+    true  => 'iam_role=auto',
+    false => undef
+  }
+
+  $mount_options = ['_netdev', 'nonempty', 'ro', 'nosuid', 'allow_other', 'multireq_max=5', 'uid=452', 'gid=452', "endpoint=${aws_region}", "url=https://s3.${aws_region}.amazonaws.com", $iam_role_mount_option]
+
+  realize Group['puppet']
+  realize User['puppet']
+
+  include profiles::s3fs
+
+  file { 'puppetserver-mfa-data':
+    ensure  => 'directory',
+    path    => '/etc/puppetlabs/code/data/mfa',
+    owner   => 'puppet',
+    group   => 'puppet',
+    require => [Group['puppet'], User['puppet']]
+  }
+
+  mount { 'puppetserver-mfa-data':
+    ensure   => 'mounted',
+    device   => $bucket,
+    name     => '/etc/puppetlabs/code/data/mfa',
+    fstype   => 'fuse.s3fs',
+    options  => join($mount_options.filter |$option| { $option }, ','),
+    remounts => false,
+    atboot   => true,
+    require  => [File['puppetserver-mfa-data'], Class['profiles::s3fs']]
+  }
+}

--- a/spec/classes/puppet/puppetserver/mfa_spec.rb
+++ b/spec/classes/puppet/puppetserver/mfa_spec.rb
@@ -1,0 +1,55 @@
+describe 'profiles::puppet::puppetserver::mfa' do
+  include_examples 'operating system support'
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      context "with bucket => publiq-configdata:/mfa" do
+        let(:params) { {
+          'bucket' => 'publiq-configdata:/mfa'
+        } }
+
+        it { is_expected.to compile.with_all_deps }
+
+        it { is_expected.to contain_class('profiles::puppet::puppetserver::mfa').with(
+          'bucket'       => 'publiq-configdata:/mfa',
+          'use_iam_role' => true,
+          'aws_region'   => 'eu-west-1'
+        ) }
+
+        it { is_expected.to contain_group('puppet') }
+        it { is_expected.to contain_user('puppet') }
+        it { is_expected.to contain_class('profiles::s3fs') }
+
+        it { is_expected.to contain_file('puppetserver-mfa-data').with(
+          'ensure' => 'directory',
+          'path'   => '/etc/puppetlabs/code/data/mfa',
+          'owner'  => 'puppet',
+          'group'  => 'puppet'
+        ) }
+
+        it { is_expected.to contain_mount('puppetserver-mfa-data').with(
+          'ensure'   => 'mounted',
+          'name'     => '/etc/puppetlabs/code/data/mfa',
+          'device'   => 'publiq-configdata:/mfa',
+          'fstype'   => 'fuse.s3fs',
+          'options'  => '_netdev,nonempty,ro,nosuid,allow_other,multireq_max=5,uid=452,gid=452,endpoint=eu-west-1,url=https://s3.eu-west-1.amazonaws.com,iam_role=auto',
+          'remounts' => false,
+          'atboot'   => true
+        ) }
+
+        it { is_expected.to contain_file('puppetserver-mfa-data').that_requires('Group[puppet]') }
+        it { is_expected.to contain_file('puppetserver-mfa-data').that_requires('User[puppet]') }
+        it { is_expected.to contain_file('puppetserver-mfa-data').that_comes_before('Mount[puppetserver-mfa-data]') }
+        it { is_expected.to contain_class('profiles::s3fs').that_comes_before('Mount[puppetserver-mfa-data]') }
+      end
+
+      context "without parameters" do
+        let(:params) { {} }
+
+        it { expect { catalogue }.to raise_error(Puppet::ParseError, /expects a value for parameter 'bucket'/) }
+      end
+    end
+  end
+end

--- a/spec/classes/puppet/puppetserver_spec.rb
+++ b/spec/classes/puppet/puppetserver_spec.rb
@@ -31,6 +31,9 @@ describe 'profiles::puppet::puppetserver' do
             'terraform_integration'  => false,
             'terraform_bucket'       => nil,
             'terraform_use_iam_role' => true,
+            'mfa_bucket'             => nil,
+            'mfa_use_iam_role'       => true,
+            'mfa_aws_region'         => 'eu-west-1',
             'puppetdb_url'           => nil,
             'puppetdb_version'       => nil,
             'initial_heap_size'      => nil,
@@ -145,6 +148,7 @@ describe 'profiles::puppet::puppetserver' do
           it { is_expected.to contain_class('profiles::puppet::puppetserver::vault') }
 
           it { is_expected.not_to contain_class('profiles::puppet::puppetserver::terraform') }
+          it { is_expected.not_to contain_class('profiles::puppet::puppetserver::mfa') }
 
           it { is_expected.to contain_cron('puppetserver_report_retention').with(
             'environment' => [ 'MAILTO=infra+cron@publiq.be'],
@@ -237,7 +241,7 @@ describe 'profiles::puppet::puppetserver' do
           end
         end
 
-        context "with version => 1.2.3, dns_alt_names => puppet.services.example.com, autosign => true, trusted_amis => ami-123, trusted_certnames => [], eyaml => true, eyaml_gpg_key => { 'id' => '6789DEFD', 'content' => '-----BEGIN PGP PRIVATE KEY BLOCK-----\neyamlkey\n-----END PGP PRIVATE KEY BLOCK-----' }, lookup_hierarchy => { name => Common data, path => common.yaml }, terraform_integration => true, terraform_bucket => mybucket, puppetdb_url => https://puppetdb.example.com:8081, initial_heap_size => 512m, maximum_heap_size => 512m, report_retention_days => 5 and service_status => stopped" do
+        context "with version => 1.2.3, dns_alt_names => puppet.services.example.com, autosign => true, trusted_amis => ami-123, trusted_certnames => [], eyaml => true, eyaml_gpg_key => { 'id' => '6789DEFD', 'content' => '-----BEGIN PGP PRIVATE KEY BLOCK-----\neyamlkey\n-----END PGP PRIVATE KEY BLOCK-----' }, lookup_hierarchy => { name => Common data, path => common.yaml }, terraform_integration => true, terraform_bucket => mybucket, mfa_bucket => configdata:/mfa, puppetdb_url => https://puppetdb.example.com:8081, initial_heap_size => 512m, maximum_heap_size => 512m, report_retention_days => 5 and service_status => stopped" do
           let(:params) { {
             'version'               => '1.2.3',
             'dns_alt_names'         => 'puppet.services.example.com',
@@ -252,6 +256,7 @@ describe 'profiles::puppet::puppetserver' do
             'lookup_hierarchy'      => { 'name' => 'Common data', 'path' => 'common.yaml' },
             'terraform_integration' => true,
             'terraform_bucket'      => 'mybucket',
+            'mfa_bucket'            => 'configdata:/mfa',
             'puppetdb_url'          => 'https://puppetdb.example.com:8081',
             'initial_heap_size'     => '512m',
             'maximum_heap_size'     => '512m',
@@ -308,6 +313,12 @@ describe 'profiles::puppet::puppetserver' do
             'use_iam_role' => true
           ) }
 
+          it { is_expected.to contain_class('profiles::puppet::puppetserver::mfa').with(
+            'bucket'       => 'configdata:/mfa',
+            'use_iam_role' => true,
+            'aws_region'   => 'eu-west-1'
+          ) }
+
           it { is_expected.to contain_class('profiles::puppet::puppetserver::puppetdb').with(
             'url'     => 'https://puppetdb.example.com:8081',
             'version' => nil
@@ -329,6 +340,7 @@ describe 'profiles::puppet::puppetserver' do
           it { is_expected.to contain_class('profiles::puppet::puppetserver::autosign').that_notifies('Class[profiles::puppet::puppetserver::service]') }
           it { is_expected.to contain_class('profiles::puppet::puppetserver::hiera').that_notifies('Class[profiles::puppet::puppetserver::service]') }
           it { is_expected.to contain_class('profiles::puppet::puppetserver::terraform').that_notifies('Class[profiles::puppet::puppetserver::service]') }
+          it { is_expected.to contain_class('profiles::puppet::puppetserver::mfa').that_notifies('Class[profiles::puppet::puppetserver::service]') }
           it { is_expected.to contain_class('profiles::puppet::puppetserver::puppetdb').that_notifies('Class[profiles::puppet::puppetserver::service]') }
           it { is_expected.to contain_augeas('puppetserver_initial_heap_size').that_requires('Class[profiles::puppet::puppetserver::install]') }
           it { is_expected.to contain_augeas('puppetserver_initial_heap_size').that_notifies('Class[profiles::puppet::puppetserver::service]') }


### PR DESCRIPTION
## Summary

  Add a separate read-only MFA configuration mount to the production Puppetserver.

  ## Changes

  - Mount publiq-configdata:/mfa at /etc/puppetlabs/code/data/mfa.
  - Add configurable MFA bucket, IAM-role, and AWS-region parameters.
  - Configure the production Puppetserver MFA bucket.
  - Add the required Terraform-managed mfa/ S3 prefix marker.
  - Add focused Puppet profile specs.