### PR TITLE
Force MFA for users with configured MFA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     if: ${{ ! github.event.pull_request.merged }}
-    runs-on: ubuntu-24.04
+    runs-on: arc-runner-set
     steps:
       - name: Checkout project
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     if: ${{ ! github.event.pull_request.merged }}
-    runs-on: arc-runner-set
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout project
         uses: actions/checkout@v4

--- a/manifests/ssh.pp
+++ b/manifests/ssh.pp
@@ -5,26 +5,34 @@ class profiles::ssh(
 ) inherits ::profiles {
 
   include ::profiles::firewall::rules
+  include ::profiles::ssh::service
 
   package { 'openssh-server':
     ensure => 'latest',
-    notify => Service['ssh']
+    notify => Class['profiles::ssh::service']
   }
 
   profiles::ssh::sshd_config { 'PermitRootLogin':
     ensure => 'present',
     value  => 'no',
-    notify  => Service['ssh']
+    notify  => Class['profiles::ssh::service']
   }
 
   profiles::ssh::sshd_config { 'PubkeyAcceptedKeyTypes':
     ensure => 'absent',
-    notify  => Service['ssh']
+    notify  => Class['profiles::ssh::service']
   }
 
-  service { 'ssh':
-    ensure => 'running',
-    enable => true
+  file { '/etc/ssh/sshd_config.d':
+    ensure => 'directory',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755'
+  }
+
+  profiles::ssh::sshd_config { 'Include':
+    value  => '/etc/ssh/sshd_config.d/*.conf',
+    notify => Class['profiles::ssh::service']
   }
 
   file { 'ssh_known_hosts':
@@ -59,6 +67,8 @@ class profiles::ssh(
     authorized_keys      => $authorized_keys,
     authorized_keys_tags => $authorized_keys_tags
   }
+
+  Class['profiles::ssh::mfa'] ~> Class['profiles::ssh::service']
 
   [$authorized_keys_tags].flatten.each |$tag| {
     Ssh_authorized_key <| tag == $tag |>

--- a/manifests/ssh.pp
+++ b/manifests/ssh.pp
@@ -54,11 +54,10 @@ class profiles::ssh(
     keys => $authorized_keys
   }
 
-  if $mfa {
-    class { 'profiles::ssh::mfa':
-      authorized_keys      => $authorized_keys,
-      authorized_keys_tags => $authorized_keys_tags
-    }
+  class { 'profiles::ssh::mfa':
+    enabled              => $mfa,
+    authorized_keys      => $authorized_keys,
+    authorized_keys_tags => $authorized_keys_tags
   }
 
   [$authorized_keys_tags].flatten.each |$tag| {

--- a/manifests/ssh/mfa.pp
+++ b/manifests/ssh/mfa.pp
@@ -1,34 +1,128 @@
 class profiles::ssh::mfa (
+  Boolean                        $enabled              = false,
   Variant[Hash, Array[Hash]]     $authorized_keys      = {},
   Variant[String, Array[String]] $authorized_keys_tags = [],
+  Array[String]                  $bypass_ips           = ['194.78.13.220'],
   String                         $mfa_directory        = '/etc/puppetlabs/code/data/mfa'
 ) inherits ::profiles {
 
   $authorized_keys_tags_array = [$authorized_keys_tags].flatten
 
-  $authorized_keys.each |String $user, Hash $attributes| {
+  $configured_users = $authorized_keys.filter |String $user, Hash $attributes| {
     $tags = $attributes['tags'] ? {
       undef   => [],
       default => [$attributes['tags']].flatten
     }
-
     $configured = $tags.any |String $tag| { $tag in $authorized_keys_tags_array }
+    $username   = slugify($user)
 
-    if $configured and $attributes['active'] != false {
-      $username = slugify($user)
-      $config   = "${mfa_directory}/${username}.conf"
+    $enabled and $configured and $attributes['active'] != false and find_file("${mfa_directory}/${username}.conf")
+  }
+  $configured_usernames = $configured_users.keys.map |String $user| { slugify($user) }
+  $mfa_addresses        = ['*'] + $bypass_ips.map |String $ip| { "!${ip}" }
 
-      if find_file($config) {
-        file { "/home/${username}/.google_authenticator":
-          ensure    => 'file',
-          owner     => $username,
-          group     => $username,
-          mode      => '0600',
-          content   => file($config),
-          show_diff => false,
-          require   => User[$username]
-        }
+  if $enabled {
+    package { 'libpam-google-authenticator':
+      ensure => 'installed'
+    }
+  }
+
+  file { '/etc/pam.d/sshd':
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('profiles/ssh/mfa/sshd.pam.erb'),
+    notify  => Service['ssh']
+  }
+
+  if $enabled {
+    Package['libpam-google-authenticator'] -> File['/etc/pam.d/sshd']
+  }
+
+  group { 'mfa_users':
+    ensure => 'present'
+  }
+
+  $authorized_keys.each |String $user, Hash $attributes| {
+    $username = slugify($user)
+    $groups   = $attributes['admin'] ? {
+      true    => ['sudo'],
+      default => []
+    }
+
+    if $username in $configured_usernames {
+      User <| title == $username |> {
+        groups => $groups + ['mfa_users']
       }
+    } else {
+      User <| title == $username |> {
+        groups => $groups
+      }
+    }
+  }
+
+  file { '/etc/ssh/sshd_config.d':
+    ensure => 'directory',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755'
+  }
+
+  if $enabled and !empty($configured_users) {
+    file { '/etc/ssh/sshd_config.d/publiq-mfa.conf':
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template('profiles/ssh/mfa/sshd_config.erb'),
+      require => File['/etc/ssh/sshd_config.d'],
+      notify  => Service['ssh']
+    }
+  } else {
+    file { '/etc/ssh/sshd_config.d/publiq-mfa.conf':
+      ensure  => 'absent',
+      require => File['/etc/ssh/sshd_config.d'],
+      notify  => Service['ssh']
+    }
+  }
+
+  profiles::ssh::sshd_config { 'Include':
+    value  => '/etc/ssh/sshd_config.d/*.conf',
+    notify => Service['ssh']
+  }
+
+  profiles::ssh::sshd_config { 'UsePAM':
+    value  => 'yes',
+    notify => Service['ssh']
+  }
+
+  profiles::ssh::sshd_config { 'ChallengeResponseAuthentication':
+    value  => $enabled ? {
+      true    => 'yes',
+      default => 'no'
+    },
+    notify => Service['ssh']
+  }
+
+  profiles::ssh::sshd_config { 'AuthenticationMethods':
+    ensure => 'absent',
+    value  => 'publickey,keyboard-interactive:pam',
+    notify => Service['ssh']
+  }
+
+  $configured_users.each |String $user, Hash $attributes| {
+    $username = slugify($user)
+    $config   = "${mfa_directory}/${username}.conf"
+
+    file { "/home/${username}/.google_authenticator":
+      ensure    => 'file',
+      owner     => $username,
+      group     => $username,
+      mode      => '0400',
+      content   => file($config),
+      show_diff => false,
+      require   => User[$username]
     }
   }
 }

--- a/manifests/ssh/mfa.pp
+++ b/manifests/ssh/mfa.pp
@@ -25,19 +25,64 @@ class profiles::ssh::mfa (
     package { 'libpam-google-authenticator':
       ensure => 'installed'
     }
-  }
 
-  file { '/etc/pam.d/sshd':
-    ensure  => 'file',
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    content => template('profiles/ssh/mfa/sshd.pam.erb'),
-    notify  => Service['ssh']
-  }
+    file { '/etc/pam.d/sshd':
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template('profiles/ssh/mfa/sshd.pam.erb'),
+      require => Package['libpam-google-authenticator']
+    }
 
-  if $enabled {
-    Package['libpam-google-authenticator'] -> File['/etc/pam.d/sshd']
+    if !empty($configured_users) {
+      file { '/etc/ssh/sshd_config.d/publiq-mfa.conf':
+        ensure  => 'file',
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        content => template('profiles/ssh/mfa/sshd_config.erb')
+      }
+    } else {
+      file { '/etc/ssh/sshd_config.d/publiq-mfa.conf':
+        ensure => 'absent'
+      }
+    }
+
+    profiles::ssh::sshd_config { 'ChallengeResponseAuthentication':
+      value => 'yes'
+    }
+
+    $configured_users.each |String $user, Hash $attributes| {
+      $username = slugify($user)
+      $config   = "${mfa_directory}/${username}.conf"
+
+      file { "/home/${username}/.google_authenticator":
+        ensure    => 'file',
+        owner     => $username,
+        group     => $username,
+        mode      => '0400',
+        content   => file($config),
+        show_diff => false,
+        require   => User[$username]
+      }
+    }
+  } else {
+    file { '/etc/pam.d/sshd':
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template('profiles/ssh/mfa/sshd.pam.erb')
+    }
+
+    file { '/etc/ssh/sshd_config.d/publiq-mfa.conf':
+      ensure => 'absent'
+    }
+
+    profiles::ssh::sshd_config { 'ChallengeResponseAuthentication':
+      value => 'no'
+    }
   }
 
   group { 'mfa_users':
@@ -62,67 +107,12 @@ class profiles::ssh::mfa (
     }
   }
 
-  file { '/etc/ssh/sshd_config.d':
-    ensure => 'directory',
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0755'
-  }
-
-  if $enabled and !empty($configured_users) {
-    file { '/etc/ssh/sshd_config.d/publiq-mfa.conf':
-      ensure  => 'file',
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0644',
-      content => template('profiles/ssh/mfa/sshd_config.erb'),
-      require => File['/etc/ssh/sshd_config.d'],
-      notify  => Service['ssh']
-    }
-  } else {
-    file { '/etc/ssh/sshd_config.d/publiq-mfa.conf':
-      ensure  => 'absent',
-      require => File['/etc/ssh/sshd_config.d'],
-      notify  => Service['ssh']
-    }
-  }
-
-  profiles::ssh::sshd_config { 'Include':
-    value  => '/etc/ssh/sshd_config.d/*.conf',
-    notify => Service['ssh']
-  }
-
   profiles::ssh::sshd_config { 'UsePAM':
-    value  => 'yes',
-    notify => Service['ssh']
-  }
-
-  profiles::ssh::sshd_config { 'ChallengeResponseAuthentication':
-    value  => $enabled ? {
-      true    => 'yes',
-      default => 'no'
-    },
-    notify => Service['ssh']
+    value => 'yes'
   }
 
   profiles::ssh::sshd_config { 'AuthenticationMethods':
     ensure => 'absent',
-    value  => 'publickey,keyboard-interactive:pam',
-    notify => Service['ssh']
-  }
-
-  $configured_users.each |String $user, Hash $attributes| {
-    $username = slugify($user)
-    $config   = "${mfa_directory}/${username}.conf"
-
-    file { "/home/${username}/.google_authenticator":
-      ensure    => 'file',
-      owner     => $username,
-      group     => $username,
-      mode      => '0400',
-      content   => file($config),
-      show_diff => false,
-      require   => User[$username]
-    }
+    value  => 'publickey,keyboard-interactive:pam'
   }
 }

--- a/manifests/ssh/service.pp
+++ b/manifests/ssh/service.pp
@@ -1,0 +1,7 @@
+class profiles::ssh::service inherits ::profiles {
+
+  service { 'ssh':
+    ensure => 'running',
+    enable => true
+  }
+}

--- a/spec/classes/ssh/mfa_spec.rb
+++ b/spec/classes/ssh/mfa_spec.rb
@@ -6,14 +6,16 @@ describe 'profiles::ssh::mfa' do
       let(:facts) { facts }
       let(:pre_condition) do
         [
+          "service { 'ssh': ensure => running }",
           "user { 'publiq-first-user': ensure => present }",
           "user { 'publiq-inactive-user': ensure => absent }"
         ]
       end
       let(:params) do
         {
+          'enabled'              => true,
           'authorized_keys'      => {
-            'Publiq First User'    => { 'tags' => ['publiq', 'bastion'] },
+            'Publiq First User'    => { 'tags' => ['publiq', 'bastion'], 'admin' => true },
             'Publiq Missing User'  => { 'tags' => 'bastion' },
             'Publiq Inactive User' => { 'tags' => 'bastion', 'active' => false },
             'Publiq Other User'    => { 'tags' => 'other' }
@@ -26,14 +28,52 @@ describe 'profiles::ssh::mfa' do
       it { is_expected.to compile.with_all_deps }
 
       it { is_expected.to contain_class('profiles::ssh::mfa').with(
-        'authorized_keys_tags' => 'bastion'
+        'enabled'              => true,
+        'authorized_keys_tags' => 'bastion',
+        'bypass_ips'           => ['194.78.13.220']
       ) }
+
+      it { is_expected.to contain_package('libpam-google-authenticator').with(
+        'ensure' => 'installed'
+      ) }
+
+      it { is_expected.to contain_group('mfa_users').with_ensure('present') }
+      it { is_expected.to contain_user('publiq-first-user').with_groups(['sudo', 'mfa_users']) }
+      it { is_expected.to contain_user('publiq-inactive-user').with_groups([]) }
+
+      it { is_expected.to contain_file('/etc/pam.d/sshd').with(
+        'ensure' => 'file',
+        'owner'  => 'root',
+        'group'  => 'root',
+        'mode'   => '0644'
+      ).without_content(%r{@include common-auth}) }
+
+      it { is_expected.to contain_file('/etc/pam.d/sshd').without_content(%r{pam_succeed_if\.so}) }
+      it { is_expected.to contain_file('/etc/pam.d/sshd').with_content(%r{pam_google_authenticator\.so nullok}) }
+      it { is_expected.to contain_file('/etc/pam.d/sshd').with_content(%r{auth required pam_permit\.so}) }
+      it { is_expected.to contain_file('/etc/pam.d/sshd').that_notifies('Service[ssh]') }
+      it { is_expected.to contain_file('/etc/pam.d/sshd').that_requires('Package[libpam-google-authenticator]') }
+
+      it { is_expected.to contain_profiles__ssh__sshd_config('UsePAM').with_value('yes') }
+      it { is_expected.to contain_profiles__ssh__sshd_config('ChallengeResponseAuthentication').with_value('yes') }
+      it { is_expected.to contain_profiles__ssh__sshd_config('AuthenticationMethods').with_ensure('absent') }
+      it { is_expected.to contain_profiles__ssh__sshd_config('Include').with_value('/etc/ssh/sshd_config.d/*.conf') }
+
+      it { is_expected.to contain_file('/etc/ssh/sshd_config.d/publiq-mfa.conf').with(
+        'ensure' => 'file',
+        'owner'  => 'root',
+        'group'  => 'root',
+        'mode'   => '0644'
+      ).with_content(%r{Match Group mfa_users Address \*,!194\.78\.13\.220}) }
+
+      it { is_expected.to contain_file('/etc/ssh/sshd_config.d/publiq-mfa.conf').with_content(%r{AuthenticationMethods publickey,keyboard-interactive:pam}) }
+      it { is_expected.to contain_file('/etc/ssh/sshd_config.d/publiq-mfa.conf').with_content(%r{Match all}) }
 
       it { is_expected.to contain_file('/home/publiq-first-user/.google_authenticator').with(
         'ensure'    => 'file',
         'owner'     => 'publiq-first-user',
         'group'     => 'publiq-first-user',
-        'mode'      => '0600',
+        'mode'      => '0400',
         'content'   => "MFA configuration\n",
         'show_diff' => false
       ) }
@@ -42,6 +82,46 @@ describe 'profiles::ssh::mfa' do
       it { is_expected.not_to contain_file('/home/publiq-missing-user/.google_authenticator') }
       it { is_expected.not_to contain_file('/home/publiq-inactive-user/.google_authenticator') }
       it { is_expected.not_to contain_file('/home/publiq-other-user/.google_authenticator') }
+
+      context 'with custom bypass IPs' do
+        let(:params) do
+          super().merge({ 'bypass_ips' => ['192.0.2.1', '198.51.100.0/24'] })
+        end
+
+        it { is_expected.to contain_file('/etc/ssh/sshd_config.d/publiq-mfa.conf').with_content(
+          %r{Match Group mfa_users Address \*,!192\.0\.2\.1,!198\.51\.100\.0/24}
+        ) }
+      end
+
+      context 'without bypass IPs' do
+        let(:params) do
+          super().merge({ 'bypass_ips' => [] })
+        end
+
+        it { is_expected.to contain_file('/etc/ssh/sshd_config.d/publiq-mfa.conf').with_content(
+          %r{Match Group mfa_users Address \*\n}
+        ) }
+      end
+
+      context 'with MFA disabled' do
+        let(:params) do
+          super().merge({ 'enabled' => false })
+        end
+
+        it { is_expected.not_to contain_package('libpam-google-authenticator') }
+
+        it { is_expected.to contain_file('/etc/pam.d/sshd').with_content(%r{@include common-auth}) }
+        it { is_expected.to contain_file('/etc/pam.d/sshd').without_content(%r{pam_google_authenticator\.so}) }
+        it { is_expected.to contain_file('/etc/pam.d/sshd').without_content(%r{pam_succeed_if\.so}) }
+
+        it { is_expected.to contain_profiles__ssh__sshd_config('UsePAM').with_value('yes') }
+        it { is_expected.to contain_profiles__ssh__sshd_config('ChallengeResponseAuthentication').with_value('no') }
+        it { is_expected.to contain_profiles__ssh__sshd_config('AuthenticationMethods').with_ensure('absent') }
+        it { is_expected.to contain_file('/etc/ssh/sshd_config.d/publiq-mfa.conf').with_ensure('absent') }
+        it { is_expected.to contain_user('publiq-first-user').with_groups(['sudo']) }
+
+        it { is_expected.not_to contain_file('/home/publiq-first-user/.google_authenticator') }
+      end
     end
   end
 end

--- a/spec/classes/ssh/mfa_spec.rb
+++ b/spec/classes/ssh/mfa_spec.rb
@@ -6,7 +6,6 @@ describe 'profiles::ssh::mfa' do
       let(:facts) { facts }
       let(:pre_condition) do
         [
-          "service { 'ssh': ensure => running }",
           "user { 'publiq-first-user': ensure => present }",
           "user { 'publiq-inactive-user': ensure => absent }"
         ]
@@ -51,14 +50,11 @@ describe 'profiles::ssh::mfa' do
       it { is_expected.to contain_file('/etc/pam.d/sshd').without_content(%r{pam_succeed_if\.so}) }
       it { is_expected.to contain_file('/etc/pam.d/sshd').with_content(%r{pam_google_authenticator\.so nullok}) }
       it { is_expected.to contain_file('/etc/pam.d/sshd').with_content(%r{auth required pam_permit\.so}) }
-      it { is_expected.to contain_file('/etc/pam.d/sshd').that_notifies('Service[ssh]') }
       it { is_expected.to contain_file('/etc/pam.d/sshd').that_requires('Package[libpam-google-authenticator]') }
 
       it { is_expected.to contain_profiles__ssh__sshd_config('UsePAM').with_value('yes') }
       it { is_expected.to contain_profiles__ssh__sshd_config('ChallengeResponseAuthentication').with_value('yes') }
       it { is_expected.to contain_profiles__ssh__sshd_config('AuthenticationMethods').with_ensure('absent') }
-      it { is_expected.to contain_profiles__ssh__sshd_config('Include').with_value('/etc/ssh/sshd_config.d/*.conf') }
-
       it { is_expected.to contain_file('/etc/ssh/sshd_config.d/publiq-mfa.conf').with(
         'ensure' => 'file',
         'owner'  => 'root',

--- a/spec/classes/ssh/service_spec.rb
+++ b/spec/classes/ssh/service_spec.rb
@@ -1,0 +1,16 @@
+describe 'profiles::ssh::service' do
+  include_examples 'operating system support'
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_service('ssh').with(
+        'ensure' => 'running',
+        'enable' => true
+      ) }
+    end
+  end
+end

--- a/spec/classes/ssh_spec.rb
+++ b/spec/classes/ssh_spec.rb
@@ -40,6 +40,17 @@ describe 'profiles::ssh' do
           'enable' => true
         ) }
 
+        it { is_expected.to contain_class('Profiles::Ssh::Service') }
+
+        it { is_expected.to contain_file('/etc/ssh/sshd_config.d').with(
+          'ensure' => 'directory',
+          'owner'  => 'root',
+          'group'  => 'root',
+          'mode'   => '0755'
+        ) }
+
+        it { is_expected.to contain_profiles__ssh__sshd_config('Include').with_value('/etc/ssh/sshd_config.d/*.conf') }
+
         it { is_expected.to contain_file('ssh_known_hosts').with(
           'ensure' => 'file',
           'path'   => '/etc/ssh/ssh_known_hosts',
@@ -60,9 +71,10 @@ describe 'profiles::ssh' do
           'keys' => {}
         ) }
 
-        it { is_expected.to contain_profiles__ssh__sshd_config('PermitRootLogin').that_notifies('Service[ssh]') }
-        it { is_expected.to contain_profiles__ssh__sshd_config('PubkeyAcceptedKeyTypes').that_notifies('Service[ssh]') }
-        it { is_expected.to contain_package('openssh-server').that_notifies('Service[ssh]') }
+        it { is_expected.to contain_profiles__ssh__sshd_config('PermitRootLogin').that_notifies('Class[Profiles::Ssh::Service]') }
+        it { is_expected.to contain_profiles__ssh__sshd_config('PubkeyAcceptedKeyTypes').that_notifies('Class[Profiles::Ssh::Service]') }
+        it { is_expected.to contain_profiles__ssh__sshd_config('Include').that_notifies('Class[Profiles::Ssh::Service]') }
+        it { is_expected.to contain_package('openssh-server').that_notifies('Class[Profiles::Ssh::Service]') }
       end
 
       context 'with hieradata' do
@@ -90,6 +102,8 @@ describe 'profiles::ssh' do
             'authorized_keys'      => authorized_keys,
             'authorized_keys_tags' => 'publiq'
           ) }
+
+          it { is_expected.to contain_class('Profiles::Ssh::Mfa').that_notifies('Class[Profiles::Ssh::Service]') }
         end
 
         context 'on AWS EC2' do

--- a/spec/classes/ssh_spec.rb
+++ b/spec/classes/ssh_spec.rb
@@ -16,7 +16,11 @@ describe 'profiles::ssh' do
           'mfa'                  => false
         ) }
 
-        it { is_expected.not_to contain_class('Profiles::Ssh::Mfa') }
+        it { is_expected.to contain_class('Profiles::Ssh::Mfa').with(
+          'enabled'              => false,
+          'authorized_keys'      => {},
+          'authorized_keys_tags' => []
+        ) }
 
         it { is_expected.to contain_package('openssh-server').with(
           'ensure' => 'latest'
@@ -82,6 +86,7 @@ describe 'profiles::ssh' do
           } }
 
           it { is_expected.to contain_class('Profiles::Ssh::Mfa').with(
+            'enabled'              => true,
             'authorized_keys'      => authorized_keys,
             'authorized_keys_tags' => 'publiq'
           ) }

--- a/templates/ssh/mfa/sshd.pam.erb
+++ b/templates/ssh/mfa/sshd.pam.erb
@@ -1,0 +1,25 @@
+# Managed by Puppet
+
+<% if @enabled -%>
+auth required pam_google_authenticator.so nullok
+auth required pam_permit.so
+<% else -%>
+@include common-auth
+<% end -%>
+
+account required pam_nologin.so
+@include common-account
+
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so close
+session required pam_loginuid.so
+session optional pam_keyinit.so force revoke
+@include common-session
+session optional pam_motd.so motd=/run/motd.dynamic
+session optional pam_motd.so noupdate
+session optional pam_mail.so standard noenv
+session required pam_limits.so
+session required pam_env.so
+session required pam_env.so user_readenv=1 envfile=/etc/default/locale
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so open
+
+@include common-password

--- a/templates/ssh/mfa/sshd_config.erb
+++ b/templates/ssh/mfa/sshd_config.erb
@@ -1,0 +1,5 @@
+# Managed by Puppet
+
+Match Group mfa_users Address <%= @mfa_addresses.join(',') %>
+  AuthenticationMethods publickey,keyboard-interactive:pam
+Match all


### PR DESCRIPTION
## Description

  Add complete SSH MFA configuration and enforcement.

  The SSH profile now manages the MFA lifecycle through an enable flag. Disabling MFA restores the standard SSH PAM authentication stack and removes MFA enforcement.

  When enabled, the MFA profile:

  - Installs Google Authenticator PAM tooling.
  - Configures SSH PAM without password authentication.
  - Creates and manages the mfa_users group.
  - Adds active users with available MFA configuration to mfa_users.
  - Removes users from mfa_users when MFA is no longer configured.
  - Preserves existing secondary groups such as sudo.
  - Requires public-key authentication followed by PAM MFA for mfa_users.
  - Allows configurable IP addresses to bypass MFA.
  - Installs user MFA configuration files with restrictive permissions.
  - Leaves users without MFA configuration unaffected.

  The GitHub Actions workflow is also updated to use the new arc-runner-set self-hosted runner.
