### PR TITLE
OPS-1557 Extend RDS manual  backup retention

### DIFF
--- a/manifests/backup/rds.pp
+++ b/manifests/backup/rds.pp
@@ -116,6 +116,6 @@ class profiles::backup::rds (
     minute      => '0',
     hour        => '1',
     weekday     => '0',
-    command     => "/bin/rm -f ${backupdir}/*.sql.gz",
+    command     => "/usr/bin/find ${backupdir} -maxdepth 1 -type f -name '*.sql.gz' -mtime +90 -delete",
   }
 }

--- a/spec/classes/backup/rds_spec.rb
+++ b/spec/classes/backup/rds_spec.rb
@@ -21,6 +21,16 @@ describe 'profiles::backup::rds' do
             'volume_size'                 => nil,
             'extra_rds_configs'           => {}
           ) }
+
+          it { is_expected.to contain_cron('rds-backup-cleanup').with(
+            'ensure'      => 'present',
+            'environment' => ['TZ=Europe/Brussels', 'MAILTO=infra+cron@publiq.be'],
+            'user'        => 'ubuntu',
+            'minute'      => '0',
+            'hour'        => '1',
+            'weekday'     => '0',
+            'command'     => "/usr/bin/find /data/rdsbackups -maxdepth 1 -type f -name '*.sql.gz' -mtime +90 -delete"
+          ) }
         end
 
         context 'with offsite_storage_public_keys => { foo => { type => ed25519, key => abcd1234 } }' do


### PR DESCRIPTION
## Summary

  Increase the retention period for manual (and thus also offsite) RDS backups from one weekly backup to backups up to 90 days old.

  ## Changes

  - Update the RDS backup cleanup cron to use `find` instead of deleting all `*.sql.gz` files.
  - Keep backup files in `/data/rdsbackups` until they are older than 90 days.
  - Add a spec expectation for the updated cleanup cron command.