### PR TITLE
Add Jenkins role-based authorization support

### DIFF
--- a/manifests/jenkins/controller.pp
+++ b/manifests/jenkins/controller.pp
@@ -16,6 +16,7 @@ class profiles::jenkins::controller (
   Variant[Array,Hash]       $pipelines           = [],
   Variant[Array,Hash]       $views               = [],
   Variant[Array,Hash]       $users               = [],
+  Boolean                   $role_based_authorization = false,
   Optional[String]          $puppetdb_url        = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
@@ -77,6 +78,7 @@ class profiles::jenkins::controller (
     pipelines           => $pipelines,
     views               => $views,
     users               => $users,
+    role_based_authorization => $role_based_authorization,
     puppetdb_url        => $puppetdb_url,
     require             => [ Class['profiles::jenkins::controller::service'], Class['profiles::jenkins::cli']]
   }

--- a/manifests/jenkins/controller/configuration.pp
+++ b/manifests/jenkins/controller/configuration.pp
@@ -44,10 +44,6 @@ class profiles::jenkins::controller::configuration(
                  'views'          => $views
                }
   }
-  $configuration_as_code_require = $role_based_authorization ? {
-    true    => [Profiles::Jenkins::Plugin['mailer'], Profiles::Jenkins::Plugin['role-strategy']],
-    default => Profiles::Jenkins::Plugin['mailer']
-  }
 
   profiles::jenkins::plugin { 'swarm': }
   profiles::jenkins::plugin { 'mailer': }
@@ -64,10 +60,13 @@ class profiles::jenkins::controller::configuration(
   profiles::jenkins::plugin { 'pipeline-stage-view': }
   profiles::jenkins::plugin { 'build-token-root': }
 
-  if $role_based_authorization {
-    profiles::jenkins::plugin { 'role-strategy':
-      notify => Class['profiles::jenkins::controller::configuration::reload']
-    }
+  profiles::jenkins::plugin { 'role-strategy':
+    ensure => $role_based_authorization ? {
+                true  => 'present',
+                false => 'absent'
+              },
+    before => Profiles::Jenkins::Plugin['configuration-as-code'],
+    notify => Class['profiles::jenkins::controller::configuration::reload']
   }
 
   profiles::jenkins::plugin { 'git':
@@ -90,7 +89,7 @@ class profiles::jenkins::controller::configuration(
 
   profiles::jenkins::plugin { 'configuration-as-code':
     configuration => $configuration_as_code_configuration,
-    require       => $configuration_as_code_require,
+    require       => Profiles::Jenkins::Plugin['mailer'],
     notify        => Class['profiles::jenkins::controller::configuration::reload']
   }
 

--- a/manifests/jenkins/controller/configuration.pp
+++ b/manifests/jenkins/controller/configuration.pp
@@ -11,6 +11,7 @@ class profiles::jenkins::controller::configuration(
   Variant[Hash, Array[Hash]] $pipelines           = [],
   Variant[Hash, Array[Hash]] $views               = [],
   Variant[Hash, Array[Hash]] $users               = [],
+  Boolean                    $role_based_authorization = false,
   Optional[String]           $puppetdb_url        = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
@@ -28,6 +29,25 @@ class profiles::jenkins::controller::configuration(
                },
     default => []
   }
+  $configuration_as_code_configuration = $role_based_authorization ? {
+    true    => {
+                 'url'                      => $url,
+                 'admin_password'           => $admin_password,
+                 'views'                    => $views,
+                 'pipelines'                => $pipelines,
+                 'users'                    => $users,
+                 'role_based_authorization' => true
+               },
+    default => {
+                 'url'            => $url,
+                 'admin_password' => $admin_password,
+                 'views'          => $views
+               }
+  }
+  $configuration_as_code_require = $role_based_authorization ? {
+    true    => [Profiles::Jenkins::Plugin['mailer'], Profiles::Jenkins::Plugin['role-strategy']],
+    default => Profiles::Jenkins::Plugin['mailer']
+  }
 
   profiles::jenkins::plugin { 'swarm': }
   profiles::jenkins::plugin { 'mailer': }
@@ -43,6 +63,12 @@ class profiles::jenkins::controller::configuration(
   profiles::jenkins::plugin { 'parameterized-scheduler': }
   profiles::jenkins::plugin { 'pipeline-stage-view': }
   profiles::jenkins::plugin { 'build-token-root': }
+
+  if $role_based_authorization {
+    profiles::jenkins::plugin { 'role-strategy':
+      notify => Class['profiles::jenkins::controller::configuration::reload']
+    }
+  }
 
   profiles::jenkins::plugin { 'git':
     configuration => {
@@ -63,12 +89,8 @@ class profiles::jenkins::controller::configuration(
   }
 
   profiles::jenkins::plugin { 'configuration-as-code':
-    configuration => {
-                       'url'            => $url,
-                       'admin_password' => $admin_password,
-                       'views'          => $views
-                     },
-    require       => Profiles::Jenkins::Plugin['mailer'],
+    configuration => $configuration_as_code_configuration,
+    require       => $configuration_as_code_require,
     notify        => Class['profiles::jenkins::controller::configuration::reload']
   }
 

--- a/spec/classes/jenkins/controller/configuration_spec.rb
+++ b/spec/classes/jenkins/controller/configuration_spec.rb
@@ -32,6 +32,7 @@ describe 'profiles::jenkins::controller::configuration' do
               'pipelines'           => [],
               'views'               => [],
               'users'               => [],
+              'role_based_authorization' => false,
               'puppetdb_url'        => 'http://localhost:8081'
             ) }
 
@@ -198,6 +199,8 @@ describe 'profiles::jenkins::controller::configuration' do
               'configuration' => nil
             ) }
 
+            it { is_expected.to_not contain_profiles__jenkins__plugin('role-strategy') }
+
             it { is_expected.to_not contain_file('jenkins users') }
 
             it { is_expected.to contain_profiles__puppet__puppetdb__cli('jenkins').with(
@@ -235,6 +238,60 @@ describe 'profiles::jenkins::controller::configuration' do
             it { is_expected.to_not contain_profiles__puppet__puppetdb__cli('jenkins') }
           end
         end
+      end
+
+      context "with role_based_authorization => true, users with groups and pipelines with authorization_groups" do
+        let(:environment) { 'testing' }
+        let(:params) { {
+          'url'                      => 'https://builds.foobar.com/',
+          'admin_password'           => 'letmein',
+          'role_based_authorization' => true,
+          'users'                    => [
+                                          { 'id' => 'foo', 'name' => 'Foo Bar', 'password' => 'baz', 'email' => 'foo@example.com', 'groups' => ['admin', 'app'] },
+                                          { 'id' => 'bar', 'name' => 'Bar Baz', 'password' => 'qux', 'email' => 'bar@example.com', 'groups' => ['app'] }
+                                        ],
+          'pipelines'                => [
+                                          { 'name' => 'App Build', 'git_url' => 'git@example.com:org/app.git', 'git_ref' => 'main', 'credential_id' => 'gitkey', 'keep_builds' => 10, 'authorization_groups' => ['app'] },
+                                          { 'name' => 'Admin Only', 'git_url' => 'git@example.com:org/admin.git', 'git_ref' => 'main', 'credential_id' => 'gitkey', 'keep_builds' => 10, 'authorization_groups' => ['admin'] }
+                                        ]
+        } }
+
+        it { is_expected.to compile.with_all_deps }
+
+        it { is_expected.to contain_profiles__jenkins__plugin('role-strategy').with(
+          'ensure'  => 'present',
+          'restart' => false
+        ) }
+
+        it { is_expected.to contain_profiles__jenkins__plugin('role-strategy').that_comes_before('Profiles::Jenkins::Plugin[configuration-as-code]') }
+        it { is_expected.to contain_profiles__jenkins__plugin('role-strategy').that_notifies('Class[profiles::jenkins::controller::configuration::reload]') }
+
+        it { is_expected.to contain_profiles__jenkins__plugin('configuration-as-code').with(
+          'configuration' => {
+                               'url'                      => 'https://builds.foobar.com/',
+                               'admin_password'           => 'letmein',
+                               'views'                    => [],
+                               'pipelines'                => [
+                                                               { 'name' => 'App Build', 'git_url' => 'git@example.com:org/app.git', 'git_ref' => 'main', 'credential_id' => 'gitkey', 'keep_builds' => 10, 'authorization_groups' => ['app'] },
+                                                               { 'name' => 'Admin Only', 'git_url' => 'git@example.com:org/admin.git', 'git_ref' => 'main', 'credential_id' => 'gitkey', 'keep_builds' => 10, 'authorization_groups' => ['admin'] }
+                                                             ],
+                               'users'                    => [
+                                                               { 'id' => 'foo', 'name' => 'Foo Bar', 'password' => 'baz', 'email' => 'foo@example.com', 'groups' => ['admin', 'app'] },
+                                                               { 'id' => 'bar', 'name' => 'Bar Baz', 'password' => 'qux', 'email' => 'bar@example.com', 'groups' => ['app'] }
+                                                             ],
+                               'role_based_authorization' => true
+                             }
+        ) }
+
+        it { is_expected.to contain_file('configuration-as-code configuration').with_content(/^\s*roleBased:$/) }
+        it { is_expected.to contain_file('configuration-as-code configuration').with_content(/^\s*- name: 'admin'$/) }
+        it { is_expected.to contain_file('configuration-as-code configuration').with_content(/^\s*- 'Overall\/Administer'$/) }
+        it { is_expected.to contain_file('configuration-as-code configuration').with_content(/^\s*- user: 'admin'$/) }
+        it { is_expected.to contain_file('configuration-as-code configuration').with_content(/^\s*- user: 'foo'$/) }
+        it { is_expected.to contain_file('configuration-as-code configuration').with_content(/^\s*- name: 'app'$/) }
+        it { is_expected.to contain_file('configuration-as-code configuration').with_content(/^\s*pattern: '\^\(app\\-build\)\$'$/) }
+        it { is_expected.to contain_file('configuration-as-code configuration').with_content(/^\s*- user: 'bar'$/) }
+        it { is_expected.to_not contain_file('configuration-as-code configuration').with_content(/admin\\-only/) }
       end
 
       context "with url => https://builds.foobar.com/, admin_password => letmein, mfa => true, docker_registry_url => https://docker.registry.com/, private_key => 'dcba4321', credentials => [{ id => 'foo', type => 'string', secret => 'bla'}, { id => 'awscred', type => 'aws', access_key => 'aws_key', secret_key => 'aws_secret'}, { id => 'userpass', type => 'username_password', username => 'foo', password => 'bar'}], global_libraries => { git_url => 'git@example.com:org/repo.git', git_ref => 'main', credential_id => 'mygitcred'}, pipelines => { 'name' => 'myrepo', 'git_url' => 'git@example.com:org/myrepo.git', 'git_ref' => 'refs/heads/main', 'credential_id' => 'mygitcred', 'keep_builds' => 5}, users => {'id' => 'foo', 'name' => 'Foo Bar', 'password' => 'baz', 'email' => 'foo@example.com'} and puppetdb_url => 'https://foobar.com:4567'" do

--- a/spec/classes/jenkins/controller/configuration_spec.rb
+++ b/spec/classes/jenkins/controller/configuration_spec.rb
@@ -250,10 +250,12 @@ describe 'profiles::jenkins::controller::configuration' do
           'role_based_authorization' => true,
           'users'                    => [
                                           { 'id' => 'foo', 'name' => 'Foo Bar', 'password' => 'baz', 'email' => 'foo@example.com', 'groups' => ['admin', 'app'] },
-                                          { 'id' => 'bar', 'name' => 'Bar Baz', 'password' => 'qux', 'email' => 'bar@example.com', 'groups' => ['app'] }
+                                          { 'id' => 'bar', 'name' => 'Bar Baz', 'password' => 'qux', 'email' => 'bar@example.com', 'groups' => ['app'] },
+                                          { 'id' => 'baz', 'name' => 'Baz Qux', 'password' => 'secret', 'email' => 'baz@example.com' }
                                         ],
           'pipelines'                => [
                                           { 'name' => 'App Build', 'git_url' => 'git@example.com:org/app.git', 'git_ref' => 'main', 'credential_id' => 'gitkey', 'keep_builds' => 10, 'authorization_groups' => ['app'] },
+                                          { 'name' => 'User Build', 'git_url' => 'git@example.com:org/user.git', 'git_ref' => 'main', 'credential_id' => 'gitkey', 'keep_builds' => 10, 'authorization_groups' => ['users'] },
                                           { 'name' => 'Admin Only', 'git_url' => 'git@example.com:org/admin.git', 'git_ref' => 'main', 'credential_id' => 'gitkey', 'keep_builds' => 10, 'authorization_groups' => ['admin'] }
                                         ]
         } }
@@ -275,11 +277,13 @@ describe 'profiles::jenkins::controller::configuration' do
                                'views'                    => [],
                                'pipelines'                => [
                                                                { 'name' => 'App Build', 'git_url' => 'git@example.com:org/app.git', 'git_ref' => 'main', 'credential_id' => 'gitkey', 'keep_builds' => 10, 'authorization_groups' => ['app'] },
+                                                               { 'name' => 'User Build', 'git_url' => 'git@example.com:org/user.git', 'git_ref' => 'main', 'credential_id' => 'gitkey', 'keep_builds' => 10, 'authorization_groups' => ['users'] },
                                                                { 'name' => 'Admin Only', 'git_url' => 'git@example.com:org/admin.git', 'git_ref' => 'main', 'credential_id' => 'gitkey', 'keep_builds' => 10, 'authorization_groups' => ['admin'] }
                                                              ],
                                'users'                    => [
                                                                { 'id' => 'foo', 'name' => 'Foo Bar', 'password' => 'baz', 'email' => 'foo@example.com', 'groups' => ['admin', 'app'] },
-                                                               { 'id' => 'bar', 'name' => 'Bar Baz', 'password' => 'qux', 'email' => 'bar@example.com', 'groups' => ['app'] }
+                                                               { 'id' => 'bar', 'name' => 'Bar Baz', 'password' => 'qux', 'email' => 'bar@example.com', 'groups' => ['app'] },
+                                                               { 'id' => 'baz', 'name' => 'Baz Qux', 'password' => 'secret', 'email' => 'baz@example.com' }
                                                              ],
                                'role_based_authorization' => true
                              }
@@ -293,6 +297,9 @@ describe 'profiles::jenkins::controller::configuration' do
         it { is_expected.to contain_file('configuration-as-code configuration').with_content(/^\s*- name: 'app'$/) }
         it { is_expected.to contain_file('configuration-as-code configuration').with_content(/^\s*pattern: '\^\(app\\-build\)\$'$/) }
         it { is_expected.to contain_file('configuration-as-code configuration').with_content(/^\s*- user: 'bar'$/) }
+        it { is_expected.to contain_file('configuration-as-code configuration').with_content(/^\s*- name: 'users'$/) }
+        it { is_expected.to contain_file('configuration-as-code configuration').with_content(/^\s*pattern: '\^\(user\\-build\)\$'$/) }
+        it { is_expected.to contain_file('configuration-as-code configuration').with_content(/^\s*- user: 'baz'$/) }
         it { is_expected.to_not contain_file('configuration-as-code configuration').with_content(/admin\\-only/) }
       end
 

--- a/spec/classes/jenkins/controller/configuration_spec.rb
+++ b/spec/classes/jenkins/controller/configuration_spec.rb
@@ -199,7 +199,9 @@ describe 'profiles::jenkins::controller::configuration' do
               'configuration' => nil
             ) }
 
-            it { is_expected.to_not contain_profiles__jenkins__plugin('role-strategy') }
+            it { is_expected.to contain_profiles__jenkins__plugin('role-strategy').with(
+              'ensure' => 'absent'
+            ) }
 
             it { is_expected.to_not contain_file('jenkins users') }
 

--- a/spec/classes/jenkins/controller_spec.rb
+++ b/spec/classes/jenkins/controller_spec.rb
@@ -33,6 +33,7 @@ describe 'profiles::jenkins::controller' do
             'pipelines'                    => [],
             'views'                        => [],
             'users'                        => [],
+            'role_based_authorization'     => false,
             'puppetdb_url'                 => 'http://localhost:8081'
           ) }
 
@@ -55,6 +56,7 @@ describe 'profiles::jenkins::controller' do
             'github_servers'      => [],
             'global_libraries'    => [],
             'users'               => [],
+            'role_based_authorization' => false,
             'puppetdb_url'        => 'http://localhost:8081'
           ) }
 
@@ -96,6 +98,7 @@ describe 'profiles::jenkins::controller' do
             'github_servers'      => [],
             'global_libraries'    => [],
             'users'               => [],
+            'role_based_authorization' => false,
             'puppetdb_url'        => nil
           ) }
         end
@@ -235,6 +238,7 @@ describe 'profiles::jenkins::controller' do
                                        {'id' => 'foo', 'name' => 'Foo Bar', 'password' => 'baz', 'email' => 'foo@example.com'},
                                        {'id' => 'user1', 'name' => 'User One', 'password' => 'passw0rd', 'email' => 'user1@example.com'}
                                      ],
+            'role_based_authorization' => false,
             'puppetdb_url'        => 'http://example.com:8081'
           ) }
 

--- a/templates/jenkins/plugin/configuration-as-code.yaml.erb
+++ b/templates/jenkins/plugin/configuration-as-code.yaml.erb
@@ -5,8 +5,64 @@ unclassified:
     url: '<%= @configuration['url'] %>'
 jenkins:
   authorizationStrategy:
+<%- if @configuration['role_based_authorization'] -%>
+    roleBased:
+      roles:
+        global:
+        - name: 'admin'
+          description: 'Jenkins administrators'
+          permissions:
+          - 'Overall/Administer'
+          entries:
+<%-
+users = [@configuration['users']].flatten.compact
+pipelines = [@configuration['pipelines']].flatten.compact
+admin_users = (['admin'] + users.select { |user| Array(user['groups']).include?('admin') }.map { |user| user['id'] }).compact.uniq
+admin_users.each do |user_id|
+-%>
+          - user: '<%= user_id.to_s.gsub("'", "''") %>'
+<%- end -%>
+        - name: 'authenticated'
+          description: 'Authenticated users'
+          permissions:
+          - 'Overall/Read'
+          entries:
+          - group: 'authenticated'
+<%-
+groups = pipelines.flat_map { |pipeline| Array(pipeline['authorization_groups']) }.compact.reject { |group| group == 'admin' }.uniq.sort
+item_roles = groups.map do |group|
+  job_names = pipelines.select { |pipeline| Array(pipeline['authorization_groups']).include?(group) }.map { |pipeline| scope().call_function('slugify', [pipeline['name']]) }.compact.uniq
+  user_ids = users.select { |user| Array(user['groups']).include?(group) }.map { |user| user['id'] }.compact.uniq
+  {
+    'group' => group,
+    'job_names' => job_names,
+    'user_ids' => user_ids,
+  }
+end.select { |role| !role['job_names'].empty? and !role['user_ids'].empty? }
+unless item_roles.empty?
+-%>
+        items:
+<%- item_roles.each do |role| -%>
+        - name: '<%= role['group'].to_s.gsub("'", "''") %>'
+          description: 'Pipelines for <%= role['group'].to_s.gsub("'", "''") %>'
+          pattern: '^(<%= role['job_names'].map { |job_name| Regexp.escape(job_name) }.join('|') %>)$'
+          permissions:
+          - 'Job/Build'
+          - 'Job/Cancel'
+          - 'Job/Discover'
+          - 'Job/Read'
+          - 'Job/Workspace'
+          - 'Run/Replay'
+          entries:
+<%- role['user_ids'].each do |user_id| -%>
+          - user: '<%= user_id.to_s.gsub("'", "''") %>'
+<%- end -%>
+<%- end -%>
+<%- end -%>
+<%- else -%>
     loggedInUsersCanDoAnything:
       allowAnonymousRead: false
+<%- end -%>
   numExecutors: 0
   slaveAgentPort: 0
   mode: NORMAL

--- a/templates/jenkins/plugin/configuration-as-code.yaml.erb
+++ b/templates/jenkins/plugin/configuration-as-code.yaml.erb
@@ -6,46 +6,48 @@ unclassified:
 jenkins:
   authorizationStrategy:
 <%- if @configuration['role_based_authorization'] -%>
+<%-
+users = [@configuration['users']].flatten.compact
+pipelines = [@configuration['pipelines']].flatten.compact
+user_groups = users.each_with_object({}) do |user, memo|
+  groups = Array(user['groups']).compact
+  memo[user['id']] = groups.empty? ? ['users'] : groups
+end
+admin_users = (['admin'] + user_groups.select { |_user_id, groups| groups.include?('admin') }.keys).compact.uniq
+pipeline_groups = pipelines.flat_map { |pipeline| Array(pipeline['authorization_groups']) }.compact.reject { |group| group == 'admin' }.uniq.sort
+item_roles = pipeline_groups.map do |group|
+  job_names = pipelines.select { |pipeline| Array(pipeline['authorization_groups']).include?(group) }.map { |pipeline| scope().call_function('slugify', [pipeline['name']]) }.compact.uniq
+  user_ids = user_groups.select { |_user_id, groups| groups.include?(group) }.keys.compact.uniq
+
+  next if job_names.empty? or user_ids.empty?
+
+  {
+    'group'     => group,
+    'pattern'   => "^(#{job_names.map { |job_name| Regexp.escape(job_name) }.join('|')})$",
+    'user_ids'  => user_ids,
+  }
+end.compact
+-%>
     roleBased:
       roles:
         global:
         - name: 'admin'
-          description: 'Jenkins administrators'
           permissions:
           - 'Overall/Administer'
           entries:
-<%-
-users = [@configuration['users']].flatten.compact
-pipelines = [@configuration['pipelines']].flatten.compact
-admin_users = (['admin'] + users.select { |user| Array(user['groups']).include?('admin') }.map { |user| user['id'] }).compact.uniq
-admin_users.each do |user_id|
--%>
+<%- admin_users.each do |user_id| -%>
           - user: '<%= user_id.to_s.gsub("'", "''") %>'
 <%- end -%>
         - name: 'authenticated'
-          description: 'Authenticated users'
           permissions:
           - 'Overall/Read'
           entries:
           - group: 'authenticated'
-<%-
-groups = pipelines.flat_map { |pipeline| Array(pipeline['authorization_groups']) }.compact.reject { |group| group == 'admin' }.uniq.sort
-item_roles = groups.map do |group|
-  job_names = pipelines.select { |pipeline| Array(pipeline['authorization_groups']).include?(group) }.map { |pipeline| scope().call_function('slugify', [pipeline['name']]) }.compact.uniq
-  user_ids = users.select { |user| Array(user['groups']).include?(group) }.map { |user| user['id'] }.compact.uniq
-  {
-    'group' => group,
-    'job_names' => job_names,
-    'user_ids' => user_ids,
-  }
-end.select { |role| !role['job_names'].empty? and !role['user_ids'].empty? }
-unless item_roles.empty?
--%>
+<%- unless item_roles.empty? -%>
         items:
 <%- item_roles.each do |role| -%>
         - name: '<%= role['group'].to_s.gsub("'", "''") %>'
-          description: 'Pipelines for <%= role['group'].to_s.gsub("'", "''") %>'
-          pattern: '^(<%= role['job_names'].map { |job_name| Regexp.escape(job_name) }.join('|') %>)$'
+          pattern: '<%= role['pattern'] %>'
           permissions:
           - 'Job/Build'
           - 'Job/Cancel'


### PR DESCRIPTION
## Summary

  Add optional role-based authorization support for Jenkins controllers.

  - Add role_based_authorization parameter to profiles::jenkins::controller.
  - Install the Jenkins role-strategy plugin when role-based authorization is enabled.
  - Render JCasC authorization using:
      - global admin role with Overall/Administer
      - authenticated users with Overall/Read
      - item roles generated from pipeline authorization_groups
      - user role assignments from each user’s groups

  - Keep the existing loggedInUsersCanDoAnything strategy as the default when the new flag is disabled.
  - Add specs for default behavior and role-based authorization rendering.
