### PR TITLE
Use long UiTdatabank event export worker timeout

### DIFF
--- a/templates/uitdatabank/entry_api/uitdatabank-event-export-worker@.service.erb
+++ b/templates/uitdatabank/entry_api/uitdatabank-event-export-worker@.service.erb
@@ -15,6 +15,7 @@ Environment=APP_INCLUDE=<%= @basedir %>/worker_bootstrap.php
 Environment=INTERVAL=1
 Environment=QUEUE=event_export
 ExecStart=/usr/bin/php resque.php
+DefaultTimeoutStopSec=900s
 Restart=on-failure
 RestartSec=10s
 Type=simple


### PR DESCRIPTION
To avoid a long running event export job being killed by systemd when
a new deployment is performed, the stop timeout for these workers is
increased to 900 seconds (from the default 90 seconds).
