### PR TITLE
Add ability to specify allowed number of concurrent builds for a project in Jenkins controller

### DIFF
--- a/manifests/jenkins/controller.pp
+++ b/manifests/jenkins/controller.pp
@@ -1,23 +1,24 @@
 class profiles::jenkins::controller (
-  Stdlib::Httpurl           $url,
-  String                    $admin_password,
-  String                    $version             = 'latest',
-  Boolean                   $mfa                 = false,
-  Boolean                   $lvm                 = false,
-  Optional[String]          $volume_group        = undef,
-  Optional[String]          $volume_size         = undef,
-  Optional[String]          $certificate         = undef,
-  Optional[Stdlib::Httpurl] $docker_registry_url = undef,
-  Optional[String]          $private_key         = undef,
-  Variant[Array,Hash]       $credentials         = [],
-  String                    $github_hook_url     = '',
-  Variant[Array,Hash]       $github_servers      = [],
-  Variant[Array,Hash]       $global_libraries    = [],
-  Variant[Array,Hash]       $pipelines           = [],
-  Variant[Array,Hash]       $views               = [],
-  Variant[Array,Hash]       $users               = [],
-  Boolean                   $role_based_authorization = false,
-  Optional[String]          $puppetdb_url        = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
+  Stdlib::Httpurl            $url,
+  String                     $admin_password,
+  String                     $version                  = 'latest',
+  Boolean                    $mfa                      = false,
+  Boolean                    $role_based_authorization = false,
+  Integer[1]                 $max_concurrent_builds    = 1,
+  Boolean                    $lvm                      = false,
+  Optional[String]           $volume_group             = undef,
+  Optional[String]           $volume_size              = undef,
+  Optional[String]           $certificate              = undef,
+  Optional[Stdlib::Httpurl]  $docker_registry_url      = undef,
+  Optional[String]           $private_key              = undef,
+  Variant[Hash, Array[Hash]] $credentials              = [],
+  String                     $github_hook_url          = '',
+  Variant[Hash, Array[Hash]] $github_servers           = [],
+  Variant[Hash, Array[Hash]] $global_libraries         = [],
+  Variant[Hash, Array[Hash]] $pipelines                = [],
+  Variant[Hash, Array[Hash]] $views                    = [],
+  Variant[Hash, Array[Hash]] $users                    = [],
+  Optional[String]           $puppetdb_url             = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   include ::profiles::java
@@ -66,21 +67,22 @@ class profiles::jenkins::controller (
   }
 
   class { '::profiles::jenkins::controller::configuration':
-    url                 => $url,
-    admin_password      => $admin_password,
-    mfa                 => $mfa,
-    docker_registry_url => $docker_registry_url,
-    private_key         => $private_key,
-    credentials         => $credentials,
-    github_hook_url     => $github_hook_url,
-    github_servers      => $github_servers,
-    global_libraries    => $global_libraries,
-    pipelines           => $pipelines,
-    views               => $views,
-    users               => $users,
+    url                      => $url,
+    admin_password           => $admin_password,
+    mfa                      => $mfa,
     role_based_authorization => $role_based_authorization,
-    puppetdb_url        => $puppetdb_url,
-    require             => [ Class['profiles::jenkins::controller::service'], Class['profiles::jenkins::cli']]
+    max_concurrent_builds    => $max_concurrent_builds,
+    docker_registry_url      => $docker_registry_url,
+    private_key              => $private_key,
+    credentials              => $credentials,
+    github_hook_url          => $github_hook_url,
+    github_servers           => $github_servers,
+    global_libraries         => $global_libraries,
+    pipelines                => $pipelines,
+    views                    => $views,
+    users                    => $users,
+    puppetdb_url             => $puppetdb_url,
+    require                  => [ Class['profiles::jenkins::controller::service'], Class['profiles::jenkins::cli']]
   }
 
   if $certificate {

--- a/manifests/jenkins/controller/configuration.pp
+++ b/manifests/jenkins/controller/configuration.pp
@@ -1,18 +1,19 @@
 class profiles::jenkins::controller::configuration(
   Stdlib::Httpurl            $url,
   String                     $admin_password,
-  Boolean                    $mfa                 = false,
-  Optional[Stdlib::Httpurl]  $docker_registry_url = undef,
-  Optional[String]           $private_key         = undef,
-  Variant[Hash, Array[Hash]] $credentials         = [],
-  String                     $github_hook_url     = '',
-  Variant[Hash, Array[Hash]] $github_servers      = [],
-  Variant[Hash, Array[Hash]] $global_libraries    = [],
-  Variant[Hash, Array[Hash]] $pipelines           = [],
-  Variant[Hash, Array[Hash]] $views               = [],
-  Variant[Hash, Array[Hash]] $users               = [],
+  Boolean                    $mfa                      = false,
   Boolean                    $role_based_authorization = false,
-  Optional[String]           $puppetdb_url        = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
+  Integer[1]                 $max_concurrent_builds    = 1,
+  Optional[Stdlib::Httpurl]  $docker_registry_url      = undef,
+  Optional[String]           $private_key              = undef,
+  Variant[Hash, Array[Hash]] $credentials              = [],
+  String                     $github_hook_url          = '',
+  Variant[Hash, Array[Hash]] $github_servers           = [],
+  Variant[Hash, Array[Hash]] $global_libraries         = [],
+  Variant[Hash, Array[Hash]] $pipelines                = [],
+  Variant[Hash, Array[Hash]] $views                    = [],
+  Variant[Hash, Array[Hash]] $users                    = [],
+  Optional[String]           $puppetdb_url             = lookup('data::puppet::puppetdb::url', Optional[String], 'first', undef)
 ) inherits ::profiles {
 
   $plain_credentials       = [$credentials].flatten.filter |$credential| { $credential['type'] == 'string' or $credential['type'] == 'file' or $credential['type'] == 'username_password' }
@@ -110,10 +111,19 @@ class profiles::jenkins::controller::configuration(
     notify        => Class['profiles::jenkins::controller::configuration::reload']
   }
 
+  profiles::jenkins::plugin { 'throttle-concurrents':
+    configuration => { 'max_concurrent_builds' => $max_concurrent_builds },
+    notify        => Class['profiles::jenkins::controller::configuration::reload']
+  }
+
   profiles::jenkins::plugin { 'job-dsl':
     configuration => {
-                       'admin_password' => $admin_password,
-                       'pipelines'      => $pipelines
+                       'admin_password'    => $admin_password,
+                       'concurrent_builds' => $max_concurrent_builds ? {
+                                                1       => false,
+                                                default => true
+                                              },
+                       'pipelines'         => $pipelines
                      },
     require       => [ Profiles::Jenkins::Plugin['git'], Profiles::Jenkins::Plugin['ssh-credentials']],
     notify        => Class['profiles::jenkins::controller::configuration::reload']

--- a/spec/classes/jenkins/controller/configuration_spec.rb
+++ b/spec/classes/jenkins/controller/configuration_spec.rb
@@ -20,20 +20,21 @@ describe 'profiles::jenkins::controller::configuration' do
             it { is_expected.to compile.with_all_deps }
 
             it { is_expected.to contain_class('profiles::jenkins::controller::configuration').with(
-              'url'                 => 'https://jenkins.foobar.com/',
-              'admin_password'      => 'passw0rd',
-              'mfa'                 => false,
-              'docker_registry_url' => nil,
-              'private_key'         => nil,
-              'credentials'         => [],
-              'github_hook_url'     => '',
-              'github_servers'      => [],
-              'global_libraries'    => [],
-              'pipelines'           => [],
-              'views'               => [],
-              'users'               => [],
+              'url'                      => 'https://jenkins.foobar.com/',
+              'admin_password'           => 'passw0rd',
+              'mfa'                      => false,
               'role_based_authorization' => false,
-              'puppetdb_url'        => 'http://localhost:8081'
+              'max_concurrent_builds'    => 1,
+              'docker_registry_url'      => nil,
+              'private_key'              => nil,
+              'credentials'              => [],
+              'github_hook_url'          => '',
+              'github_servers'           => [],
+              'global_libraries'         => [],
+              'pipelines'                => [],
+              'views'                    => [],
+              'users'                    => [],
+              'puppetdb_url'             => 'http://localhost:8081'
             ) }
 
 
@@ -173,8 +174,9 @@ describe 'profiles::jenkins::controller::configuration' do
               'ensure'        => 'present',
               'restart'       => false,
               'configuration' => {
-                                   'admin_password' => 'passw0rd',
-                                   'pipelines'      => []
+                                   'admin_password'    => 'passw0rd',
+                                   'concurrent_builds' => false,
+                                   'pipelines'         => []
                                  }
             ) }
 
@@ -202,6 +204,12 @@ describe 'profiles::jenkins::controller::configuration' do
             it { is_expected.to contain_profiles__jenkins__plugin('role-strategy').with(
               'ensure'  => 'present',
               'restart' => false
+            ) }
+
+            it { is_expected.to contain_profiles__jenkins__plugin('throttle-concurrents').with(
+              'ensure'        => 'present',
+              'restart'       => false,
+              'configuration' => { 'max_concurrent_builds' => 1 }
             ) }
 
             it { is_expected.to_not contain_file('jenkins users') }
@@ -232,6 +240,7 @@ describe 'profiles::jenkins::controller::configuration' do
             it { is_expected.to contain_profiles__jenkins__plugin('github').that_notifies('Class[profiles::jenkins::controller::configuration::reload]') }
             it { is_expected.to contain_profiles__jenkins__plugin('configuration-as-code').that_notifies('Class[profiles::jenkins::controller::configuration::reload]') }
             it { is_expected.to contain_profiles__jenkins__plugin('docker-workflow').that_notifies('Class[profiles::jenkins::controller::configuration::reload]') }
+            it { is_expected.to contain_profiles__jenkins__plugin('throttle-concurrents').that_notifies('Class[profiles::jenkins::controller::configuration::reload]') }
             it { is_expected.to contain_class('profiles::jenkins::cli::credentials').that_requires('Class[profiles::jenkins::controller::configuration::reload]') }
           end
 
@@ -243,12 +252,13 @@ describe 'profiles::jenkins::controller::configuration' do
         end
       end
 
-      context "with role_based_authorization => true, users with groups and admin pipelines" do
+      context "with url => https://builds.foobar.com/, admin_password => letmein, role_based_authorization => true, max_concurrent_builds => 3, users with groups and admin pipelines" do
         let(:environment) { 'testing' }
         let(:params) { {
           'url'                      => 'https://builds.foobar.com/',
           'admin_password'           => 'letmein',
           'role_based_authorization' => true,
+          'max_concurrent_builds'    => 3,
           'users'                    => [
                                           { 'id' => 'foo', 'name' => 'Foo Bar', 'password' => 'baz', 'email' => 'foo@example.com', 'groups' => ['admin', 'app'] },
                                           { 'id' => 'bar', 'name' => 'Bar Baz', 'password' => 'qux', 'email' => 'bar@example.com', 'groups' => ['app'] },
@@ -262,6 +272,26 @@ describe 'profiles::jenkins::controller::configuration' do
         } }
 
         it { is_expected.to compile.with_all_deps }
+
+        it { is_expected.to contain_profiles__jenkins__plugin('job-dsl').with(
+          'ensure'        => 'present',
+          'restart'       => false,
+          'configuration' => {
+                               'admin_password'    => 'letmein',
+                               'concurrent_builds' => true,
+                               'pipelines'         => [
+                                                        { 'name' => 'App Build', 'git_url' => 'git@example.com:org/app.git', 'git_ref' => 'main', 'credential_id' => 'gitkey', 'keep_builds' => 10 },
+                                                        { 'name' => 'Team Build', 'git_url' => 'git@example.com:org/team.git', 'git_ref' => 'main', 'credential_id' => 'gitkey', 'keep_builds' => 10, 'authorization_groups' => ['app'] },
+                                                        { 'name' => 'Admin Only', 'git_url' => 'git@example.com:org/admin.git', 'git_ref' => 'main', 'credential_id' => 'gitkey', 'keep_builds' => 10, 'authorization_groups' => ['admin'] }
+                                                      ]
+                             }
+        ) }
+
+        it { is_expected.to contain_profiles__jenkins__plugin('throttle-concurrents').with(
+          'ensure'        => 'present',
+          'restart'       => false,
+          'configuration' => { 'max_concurrent_builds' => 3 }
+        ) }
 
         it { is_expected.to contain_profiles__jenkins__plugin('role-strategy').with(
           'ensure'  => 'present',
@@ -417,14 +447,15 @@ describe 'profiles::jenkins::controller::configuration' do
             'ensure'        => 'present',
             'restart'       => false,
             'configuration' => {
-                                 'admin_password' => 'letmein',
-                                 'pipelines'      => {
-                                                       'name' => 'myrepo',
-                                                       'git_url' => 'git@example.com:org/myrepo.git',
-                                                       'git_ref' => 'refs/heads/main',
-                                                       'credential_id' => 'mygitcred',
-                                                       'keep_builds' => 5
-                                                     }
+                                 'admin_password'    => 'letmein',
+                                 'concurrent_builds' => false,
+                                 'pipelines'         => {
+                                                          'name' => 'myrepo',
+                                                          'git_url' => 'git@example.com:org/myrepo.git',
+                                                          'git_ref' => 'refs/heads/main',
+                                                          'credential_id' => 'mygitcred',
+                                                          'keep_builds' => 5
+                                                        }
                                }
           ) }
 
@@ -583,20 +614,21 @@ describe 'profiles::jenkins::controller::configuration' do
           'ensure'        => 'present',
           'restart'       => false,
           'configuration' => {
-                               'admin_password' => 'letmein',
-                               'pipelines'      => [{
-                                                     'name'          => 'baz',
-                                                     'git_url'       => 'git@github.com:bar/baz.git',
-                                                     'git_ref'       => 'refs/heads/develop',
-                                                     'credential_id' => 'gitkey',
-                                                     'keep_builds'   => 10
-                                                   }, {
-                                                     'name'          => 'repo',
-                                                     'git_url'       => 'git@example.com:org/repo.git',
-                                                     'git_ref'       => 'main',
-                                                     'credential_id' => 'mygitcred',
-                                                     'keep_builds'   => 2
-                                                   }]
+                               'admin_password'    => 'letmein',
+                               'concurrent_builds' => false,
+                               'pipelines'         => [{
+                                                        'name'          => 'baz',
+                                                        'git_url'       => 'git@github.com:bar/baz.git',
+                                                        'git_ref'       => 'refs/heads/develop',
+                                                        'credential_id' => 'gitkey',
+                                                        'keep_builds'   => 10
+                                                      }, {
+                                                        'name'          => 'repo',
+                                                        'git_url'       => 'git@example.com:org/repo.git',
+                                                        'git_ref'       => 'main',
+                                                        'credential_id' => 'mygitcred',
+                                                        'keep_builds'   => 2
+                                                      }]
                               }
         ) }
 

--- a/spec/classes/jenkins/controller_spec.rb
+++ b/spec/classes/jenkins/controller_spec.rb
@@ -18,23 +18,24 @@ describe 'profiles::jenkins::controller' do
           it { is_expected.to compile.with_all_deps }
 
           it { is_expected.to contain_class('profiles::jenkins::controller').with(
-            'url'                          => 'https://jenkins.example.com/',
-            'admin_password'               => 'passw0rd',
-            'version'                      => 'latest',
-            'mfa'                          => false,
-            'lvm'                          => false,
-            'certificate'                  => nil,
-            'docker_registry_url'          => nil,
-            'private_key'                  => nil,
-            'credentials'                  => [],
-            'github_hook_url'              => '',
-            'github_servers'               => [],
-            'global_libraries'             => [],
-            'pipelines'                    => [],
-            'views'                        => [],
-            'users'                        => [],
-            'role_based_authorization'     => false,
-            'puppetdb_url'                 => 'http://localhost:8081'
+            'url'                      => 'https://jenkins.example.com/',
+            'admin_password'           => 'passw0rd',
+            'version'                  => 'latest',
+            'mfa'                      => false,
+            'role_based_authorization' => false,
+            'max_concurrent_builds'    => 1,
+            'lvm'                      => false,
+            'certificate'              => nil,
+            'docker_registry_url'      => nil,
+            'private_key'              => nil,
+            'credentials'              => [],
+            'github_hook_url'          => '',
+            'github_servers'           => [],
+            'global_libraries'         => [],
+            'pipelines'                => [],
+            'views'                    => [],
+            'users'                    => [],
+            'puppetdb_url'             => 'http://localhost:8081'
           ) }
 
           it { is_expected.to contain_class('profiles::java') }
@@ -46,18 +47,19 @@ describe 'profiles::jenkins::controller' do
           ) }
 
           it { is_expected.to contain_class('profiles::jenkins::controller::configuration').with(
-            'url'                 => 'https://jenkins.example.com/',
-            'admin_password'      => 'passw0rd',
-            'mfa'                 => false,
-            'docker_registry_url' => nil,
-            'private_key'         => nil,
-            'credentials'         => [],
-            'github_hook_url'     => '',
-            'github_servers'      => [],
-            'global_libraries'    => [],
-            'users'               => [],
+            'url'                      => 'https://jenkins.example.com/',
+            'admin_password'           => 'passw0rd',
+            'mfa'                      => false,
             'role_based_authorization' => false,
-            'puppetdb_url'        => 'http://localhost:8081'
+            'max_concurrent_builds'    => 1,
+            'docker_registry_url'      => nil,
+            'private_key'              => nil,
+            'credentials'              => [],
+            'github_hook_url'          => '',
+            'github_servers'           => [],
+            'global_libraries'         => [],
+            'users'                    => [],
+            'puppetdb_url'             => 'http://localhost:8081'
           ) }
 
           it { is_expected.to contain_class('profiles::jenkins::controller::service') }
@@ -107,61 +109,63 @@ describe 'profiles::jenkins::controller' do
       context "with volume_group datavg present" do
         let(:pre_condition) { 'volume_group { "datavg": ensure => "present" }' }
 
-        context "with url => https://foobar.example.com/, admin_password => letmein, mfa => true, certificate => foobar.example.com, version => 1.2.3, lvm => true, volume_group => datavg, volume_size => 20G, docker_registry_url => https://my.docker.registry.com/, private_key => abcd1234, credentials => [{ id => 'token1', type => 'string', secret => 'secret1'}, { id => 'token2', type => 'string', secret => 'secret2'}], global_libraries => [{'git_url' => 'git@foo.com:bar/baz.git', 'git_ref' => 'develop', 'credential_id' => 'gitkey'}, {'git_url' => 'git@example.com:org/repo.git', 'git_ref' => 'main', 'credential_id' => 'mygitcred'}], pipelines => [{ 'name' => 'baz', 'git_url' => 'git@github.com:bar/baz.git', 'git_ref' => 'refs/heads/develop', 'credential_id' => 'gitkey', keep_builds => 10 }, { 'name' => 'repo', 'git_url' => 'git@example.com:org/repo.git', 'git_ref' => 'main', 'credential_id' => 'mygitcred', keep_builds => '2' }], views => [{ 'name' => 'testview', 'regex' => 'Test.*' }], users => [{'id' => 'foo', 'name' => 'Foo Bar', 'password' => 'baz', 'email' => 'foo@example.com'}, {'id' => 'user1', 'name' => 'User One', 'password' => 'passw0rd', 'email' => 'user1@example.com'}] and puppetdb_url => 'http://example.com:8081'" do
+        context "with url => https://foobar.example.com/, admin_password => letmein, mfa => true, role_based_authorization => true, max_concurrent_builds => 3, certificate => foobar.example.com, version => 1.2.3, lvm => true, volume_group => datavg, volume_size => 20G, docker_registry_url => https://my.docker.registry.com/, private_key => abcd1234, credentials => [{ id => 'token1', type => 'string', secret => 'secret1'}, { id => 'token2', type => 'string', secret => 'secret2'}], global_libraries => [{'git_url' => 'git@foo.com:bar/baz.git', 'git_ref' => 'develop', 'credential_id' => 'gitkey'}, {'git_url' => 'git@example.com:org/repo.git', 'git_ref' => 'main', 'credential_id' => 'mygitcred'}], pipelines => [{ 'name' => 'baz', 'git_url' => 'git@github.com:bar/baz.git', 'git_ref' => 'refs/heads/develop', 'credential_id' => 'gitkey', keep_builds => 10 }, { 'name' => 'repo', 'git_url' => 'git@example.com:org/repo.git', 'git_ref' => 'main', 'credential_id' => 'mygitcred', keep_builds => '2' }], views => [{ 'name' => 'testview', 'regex' => 'Test.*' }], users => [{'id' => 'foo', 'name' => 'Foo Bar', 'password' => 'baz', 'email' => 'foo@example.com'}, {'id' => 'user1', 'name' => 'User One', 'password' => 'passw0rd', 'email' => 'user1@example.com'}] and puppetdb_url => 'http://example.com:8081'" do
           let(:params) { {
-            'url'                 => 'https://foobar.example.com/',
-            'admin_password'      => 'letmein',
-            'mfa'                 => true,
-            'certificate'         => 'foobar.example.com',
-            'version'             => '1.2.3',
-            'lvm'                 => true,
-            'volume_group'        => 'datavg',
-            'volume_size'         => '20G',
-            'docker_registry_url' => 'https://my.docker.registry.com/',
-            'private_key'         => 'abcd1234',
-            'credentials'         => [
-                                       { 'id' => 'token1', 'type' => 'string', 'secret' => 'secret1'},
-                                       { 'id' => 'token2', 'type' => 'string', 'secret' => 'secret2'}
-                                     ],
-            'global_libraries'    => [
-                                       {
-                                         'git_url'       => 'git@foo.com:bar/baz.git',
-                                         'git_ref'       => 'develop',
-                                         'credential_id' => 'gitkey'
-                                       },
-                                       {
-                                         'git_url'       => 'git@example.com:org/repo.git',
-                                         'git_ref'       => 'main',
-                                         'credential_id' => 'mygitcred'
-                                       }
-                                     ],
-            'pipelines'           => [
-                                       {
-                                         'name'          => 'baz',
-                                         'git_url'       => 'git@github.com:bar/baz.git',
-                                         'git_ref'       => 'refs/heads/develop',
-                                         'credential_id' => 'gitkey',
-                                         'keep_builds'   => 10
-                                       },
-                                       {
-                                         'name'          => 'repo',
-                                         'git_url'       => 'git@example.com:org/repo.git',
-                                         'git_ref'       => 'main',
-                                         'credential_id' => 'mygitcred',
-                                         'keep_builds'   => 2
-                                       }
-                                     ],
-            'views'               => [
-                                       {
-                                         'name'  => 'testview',
-                                         'regex' => 'Test.*'
-                                       }
-                                     ],
-            'users'               => [
-                                       {'id' => 'foo', 'name' => 'Foo Bar', 'password' => 'baz', 'email' => 'foo@example.com'},
-                                       {'id' => 'user1', 'name' => 'User One', 'password' => 'passw0rd', 'email' => 'user1@example.com'}
-                                     ],
-            'puppetdb_url'        => 'http://example.com:8081'
+            'url'                      => 'https://foobar.example.com/',
+            'admin_password'           => 'letmein',
+            'mfa'                      => true,
+            'role_based_authorization' => true,
+            'max_concurrent_builds'    => 3,
+            'certificate'              => 'foobar.example.com',
+            'version'                  => '1.2.3',
+            'lvm'                      => true,
+            'volume_group'             => 'datavg',
+            'volume_size'              => '20G',
+            'docker_registry_url'      => 'https://my.docker.registry.com/',
+            'private_key'              => 'abcd1234',
+            'credentials'              => [
+                                            { 'id' => 'token1', 'type' => 'string', 'secret' => 'secret1'},
+                                            { 'id' => 'token2', 'type' => 'string', 'secret' => 'secret2'}
+                                          ],
+            'global_libraries'         => [
+                                            {
+                                              'git_url'       => 'git@foo.com:bar/baz.git',
+                                              'git_ref'       => 'develop',
+                                              'credential_id' => 'gitkey'
+                                            },
+                                            {
+                                              'git_url'       => 'git@example.com:org/repo.git',
+                                              'git_ref'       => 'main',
+                                              'credential_id' => 'mygitcred'
+                                            }
+                                          ],
+            'pipelines'                => [
+                                            {
+                                              'name'          => 'baz',
+                                              'git_url'       => 'git@github.com:bar/baz.git',
+                                              'git_ref'       => 'refs/heads/develop',
+                                              'credential_id' => 'gitkey',
+                                              'keep_builds'   => 10
+                                            },
+                                            {
+                                              'name'          => 'repo',
+                                              'git_url'       => 'git@example.com:org/repo.git',
+                                              'git_ref'       => 'main',
+                                              'credential_id' => 'mygitcred',
+                                              'keep_builds'   => 2
+                                            }
+                                          ],
+            'views'                    => [
+                                            {
+                                              'name'  => 'testview',
+                                              'regex' => 'Test.*'
+                                            }
+                                          ],
+            'users'                    => [
+                                            {'id' => 'foo', 'name' => 'Foo Bar', 'password' => 'baz', 'email' => 'foo@example.com'},
+                                            {'id' => 'user1', 'name' => 'User One', 'password' => 'passw0rd', 'email' => 'user1@example.com'}
+                                          ],
+            'puppetdb_url'             => 'http://example.com:8081'
           } }
 
           it { is_expected.to compile.with_all_deps }
@@ -191,55 +195,56 @@ describe 'profiles::jenkins::controller' do
           ) }
 
           it { is_expected.to contain_class('profiles::jenkins::controller::configuration').with(
-            'url'                 => 'https://foobar.example.com/',
-            'admin_password'      => 'letmein',
-            'mfa'                 => true,
-            'docker_registry_url' => 'https://my.docker.registry.com/',
-            'private_key'         => 'abcd1234',
-            'credentials'         => [
-                                       { 'id' => 'token1', 'type' => 'string', 'secret' => 'secret1'},
-                                       { 'id' => 'token2', 'type' => 'string', 'secret' => 'secret2'}
-                                     ],
-            'global_libraries'    => [
-                                       {
-                                         'git_url'       => 'git@foo.com:bar/baz.git',
-                                         'git_ref'       => 'develop',
-                                         'credential_id' => 'gitkey'
-                                       },
-                                       {
-                                         'git_url'       => 'git@example.com:org/repo.git',
-                                         'git_ref'       => 'main',
-                                         'credential_id' => 'mygitcred'
-                                       }
-                                     ],
-            'pipelines'           => [
-                                       {
-                                         'name'          => 'baz',
-                                         'git_url'       => 'git@github.com:bar/baz.git',
-                                         'git_ref'       => 'refs/heads/develop',
-                                         'credential_id' => 'gitkey',
-                                         'keep_builds'   => 10
-                                       },
-                                       {
-                                         'name'          => 'repo',
-                                         'git_url'       => 'git@example.com:org/repo.git',
-                                         'git_ref'       => 'main',
-                                         'credential_id' => 'mygitcred',
-                                         'keep_builds'   => 2
-                                       }
-                                     ],
-            'views'               => [
-                                       {
-                                         'name'  => 'testview',
-                                         'regex' => 'Test.*'
-                                       }
-                                     ],
-            'users'               => [
-                                       {'id' => 'foo', 'name' => 'Foo Bar', 'password' => 'baz', 'email' => 'foo@example.com'},
-                                       {'id' => 'user1', 'name' => 'User One', 'password' => 'passw0rd', 'email' => 'user1@example.com'}
-                                     ],
-            'role_based_authorization' => false,
-            'puppetdb_url'        => 'http://example.com:8081'
+            'url'                      => 'https://foobar.example.com/',
+            'admin_password'           => 'letmein',
+            'mfa'                      => true,
+            'role_based_authorization' => true,
+            'max_concurrent_builds'    => 3,
+            'docker_registry_url'      => 'https://my.docker.registry.com/',
+            'private_key'              => 'abcd1234',
+            'credentials'              => [
+                                            { 'id' => 'token1', 'type' => 'string', 'secret' => 'secret1'},
+                                            { 'id' => 'token2', 'type' => 'string', 'secret' => 'secret2'}
+                                          ],
+            'global_libraries'         => [
+                                            {
+                                              'git_url'       => 'git@foo.com:bar/baz.git',
+                                              'git_ref'       => 'develop',
+                                              'credential_id' => 'gitkey'
+                                            },
+                                            {
+                                              'git_url'       => 'git@example.com:org/repo.git',
+                                              'git_ref'       => 'main',
+                                              'credential_id' => 'mygitcred'
+                                            }
+                                          ],
+            'pipelines'                => [
+                                            {
+                                              'name'          => 'baz',
+                                              'git_url'       => 'git@github.com:bar/baz.git',
+                                              'git_ref'       => 'refs/heads/develop',
+                                              'credential_id' => 'gitkey',
+                                              'keep_builds'   => 10
+                                            },
+                                            {
+                                              'name'          => 'repo',
+                                              'git_url'       => 'git@example.com:org/repo.git',
+                                              'git_ref'       => 'main',
+                                              'credential_id' => 'mygitcred',
+                                              'keep_builds'   => 2
+                                            }
+                                          ],
+            'views'                    => [
+                                            {
+                                              'name'  => 'testview',
+                                              'regex' => 'Test.*'
+                                            }
+                                          ],
+            'users'                    => [
+                                            {'id' => 'foo', 'name' => 'Foo Bar', 'password' => 'baz', 'email' => 'foo@example.com'},
+                                            {'id' => 'user1', 'name' => 'User One', 'password' => 'passw0rd', 'email' => 'user1@example.com'}
+                                          ],
+            'puppetdb_url'             => 'http://example.com:8081'
           ) }
 
           it { is_expected.to contain_class('profiles::jenkins::cli').with(

--- a/spec/defines/jenkins/plugin_spec.rb
+++ b/spec/defines/jenkins/plugin_spec.rb
@@ -652,6 +652,77 @@ describe 'profiles::jenkins::plugin' do
           it { is_expected.to contain_file('openmfa configuration').with_content(/^\s*issuer: 'snafu'$/) }
         end
       end
+
+      context "with title throttle-concurrents" do
+        let(:title) { 'throttle-concurrents' }
+
+        context "with configuration => { 'max_concurrent_builds' => 1 }" do
+          let(:params) { {
+              'configuration' => { 'max_concurrent_builds' => 1 }
+          } }
+
+          it { is_expected.to contain_file('throttle-concurrents configuration').with(
+            'ensure'  => 'file',
+            'path'    => '/var/lib/jenkins/casc_config/throttle-concurrents.yaml',
+            'owner'   => 'jenkins',
+            'group'   => 'jenkins'
+          ) }
+
+          context 'with throttle-concurrents configuration YAML loaded' do
+            let(:content) { YAML.load(catalogue.resource('file', 'throttle-concurrents configuration').send(:parameters)[:content]) }
+
+            it { expect(content['unclassified']).to eq({ 'throttleJobProperty' => {} }) }
+          end
+        end
+
+        context "with configuration => { max_concurrent_builds => 3 }" do
+          let(:params) { {
+              'configuration' => { 'max_concurrent_builds' => 3 }
+          } }
+
+          context 'with throttle-concurrents configuration YAML loaded' do
+            let(:content) { YAML.load(catalogue.resource('file', 'throttle-concurrents configuration').send(:parameters)[:content]) }
+
+            it { expect(content['unclassified']).to eq(
+              {
+                'throttleJobProperty' => {
+                                           'categories' => [
+                                             {
+                                               'categoryName' => 'Concurrent',
+                                               'maxConcurrentPerNode' => 1,
+                                               'maxConcurrentTotal' => 3
+                                             }
+                                           ]
+                                         }
+              }
+            ) }
+          end
+        end
+
+        context "with configuration => { max_concurrent_builds => 42 }" do
+          let(:params) { {
+              'configuration' => { 'max_concurrent_builds' => 42 }
+          } }
+
+          context 'with throttle-concurrents configuration YAML loaded' do
+            let(:content) { YAML.load(catalogue.resource('file', 'throttle-concurrents configuration').send(:parameters)[:content]) }
+
+            it { expect(content['unclassified']).to eq(
+              {
+                'throttleJobProperty' => {
+                                           'categories' => [
+                                             {
+                                               'categoryName' => 'Concurrent',
+                                               'maxConcurrentPerNode' => 1,
+                                               'maxConcurrentTotal' => 42
+                                             }
+                                           ]
+                                         }
+              }
+            ) }
+          end
+        end
+      end
     end
   end
 end

--- a/spec/defines/jenkins/plugin_spec.rb
+++ b/spec/defines/jenkins/plugin_spec.rb
@@ -399,11 +399,12 @@ describe 'profiles::jenkins::plugin' do
         context 'on node jenkins.example.com' do
           let(:node) { 'jenkins.example.com' }
 
-          context "with configuration => { admin_password => secret, pipelines => {} }" do
+          context "with configuration => { admin_password => secret, concurrent_builds => false, pipelines => {} }" do
             let(:params) { {
               'configuration' => {
-                                   'admin_password' => 'secret',
-                                   'pipelines'      => {}
+                                   'admin_password'    => 'secret',
+                                   'concurrent_builds' => false,
+                                   'pipelines'         => {}
                                  }
             } }
 
@@ -456,20 +457,21 @@ describe 'profiles::jenkins::plugin' do
             it { is_expected.to contain_file('job-dsl configuration').with_content(/^\s*projectNames\('\*'\)$/) }
           end
 
-          context "with configuration => { admin_password => mypass, pipelines => { 'name' => 'testrepo', 'git_url' => 'git@example.com:org/testrepo.git', 'git_ref' => 'refs/heads/master', 'credential_id' => 'mygitcred', 'auto_build' => false, 'keep_builds' => 7, 'abort_previous' => true }}" do
+          context "with configuration => { admin_password => mypass, concurrent_builds => true, pipelines => { 'name' => 'testrepo', 'git_url' => 'git@example.com:org/testrepo.git', 'git_ref' => 'refs/heads/master', 'credential_id' => 'mygitcred', 'auto_build' => false, 'keep_builds' => 7, 'abort_previous' => true }}" do
             let(:params) { {
               'configuration' => {
-                                   'admin_password' => 'mypass',
-                                   'pipelines'      => {
-                                                         'name'           => 'testrepo',
-                                                         'git_url'        => 'git@example.com:org/testrepo.git',
-                                                         'git_ref'        => 'refs/heads/master',
-                                                         'credential_id'  => 'mygitcred',
-                                                         'auto_build'     => false,
-                                                         'keep_builds'    => 7,
-                                                         'abort_previous' => true
-                                                       }
-                                 }
+                                   'admin_password'    => 'mypass',
+                                   'concurrent_builds' => true,
+                                   'pipelines'         => {
+                                                            'name'           => 'testrepo',
+                                                            'git_url'        => 'git@example.com:org/testrepo.git',
+                                                            'git_ref'        => 'refs/heads/master',
+                                                            'credential_id'  => 'mygitcred',
+                                                            'auto_build'     => false,
+                                                            'keep_builds'    => 7,
+                                                            'abort_previous' => true
+                                                          }
+                                   }
             } }
 
             it { is_expected.to contain_file('job-dsl configuration').with_content(/^\s*pipelineJob\('testrepo'\)/) }
@@ -483,47 +485,48 @@ describe 'profiles::jenkins::plugin' do
             it { is_expected.to_not contain_file('job-dsl configuration').with_content(/^\s*githubPush\(\)$/) }
             it { is_expected.to contain_file('job-dsl configuration').with_content(/^\s*numToKeepStr\('7'\)$/) }
             it { is_expected.to_not contain_file('job-dsl configuration').with_content(/^\s*parameters {\n\s*}$/) }
-            it { is_expected.to contain_file('job-dsl configuration').with_content(/^\s*disableConcurrentBuilds { abortPrevious\(true\) }$/) }
+            it { is_expected.to_not contain_file('job-dsl configuration').with_content(/^\s*disableConcurrentBuilds .*$/) }
           end
 
-          context "with configuration => { admin_password => mypassword, pipelines => [{ 'name' => 'Baz Test', 'git_url' => 'git@github.com:bar/baz.git', 'git_ref' => 'refs/heads/develop', 'jenkinsfile_path' => 'Jenkinsfile.baz', 'credential_id' => 'gitkey', keep_builds => 10, remote_trigger => true, parameters => booleanParam { name('Flag') defaultValue(true) description('Boolean flag')} }, { 'name' => 'repo', 'git_url' => 'git@example.com:org/repo.git', 'git_ref' => 'main', 'jenkinsfile_path' => 'pipelines/Jenkinsfile.repo', 'credential_id' => 'mygitcred', keep_builds => '2', parameters => parameters => stringParam { name('String') defaultValue('') description('String parameter example') trim(true)} booleanParam { name('Myflag') defaultValue(true) description('Boolean flag example')} }] }" do
+          context "with configuration => { admin_password => mypassword, concurrent_builds => false, pipelines => [{ 'name' => 'Baz Test', 'git_url' => 'git@github.com:bar/baz.git', 'git_ref' => 'refs/heads/develop', 'jenkinsfile_path' => 'Jenkinsfile.baz', 'credential_id' => 'gitkey', keep_builds => 10, remote_trigger => true, parameters => booleanParam { name('Flag') defaultValue(true) description('Boolean flag')} }, { 'name' => 'repo', 'git_url' => 'git@example.com:org/repo.git', 'git_ref' => 'main', 'jenkinsfile_path' => 'pipelines/Jenkinsfile.repo', 'credential_id' => 'mygitcred', keep_builds => '2', parameters => parameters => stringParam { name('String') defaultValue('') description('String parameter example') trim(true)} booleanParam { name('Myflag') defaultValue(true) description('Boolean flag example')} }] }" do
             let(:params) { {
                 'configuration' => {
-                                     'admin_password' => 'mypassword',
-                                     'pipelines'      => [{
-                                                           'name'             => 'Baz Test',
-                                                           'git_url'          => 'git@github.com:bar/baz.git',
-                                                           'git_ref'          => 'refs/heads/develop',
-                                                           'jenkinsfile_path' => 'Jenkinsfile.baz',
-                                                           'credential_id'    => 'gitkey',
-                                                           'keep_builds'      => 10,
-                                                           'remote_trigger'   => true,
-                                                           'parameters'       => "booleanParam {
-                                                                                    name('Flag')
-                                                                                    defaultValue(true)
-                                                                                    description('Boolean flag')
-                                                                                  }"
-                                                         },
-                                                         {
-                                                           'name'             => ' Répo foö  ',
-                                                           'git_url'          => 'git@example.com:org/repo.git',
-                                                           'git_ref'          => 'main',
-                                                           'jenkinsfile_path' => 'pipelines/Jenkinsfile.repo',
-                                                           'credential_id'    => 'mygitcred',
-                                                           'keep_builds'      => 2,
-                                                           'parameters'       => "stringParam {
-                                                                                    name('String')
-                                                                                    defaultValue('')
-                                                                                    description('String parameter example')
-                                                                                    trim(true)
-                                                                                  }
-                                                                                  booleanParam {
-                                                                                    name('Myflag')
-                                                                                    defaultValue(false)
-                                                                                    description('Boolean flag example')
-                                                                                  }"
-                                                         }]
-                                   }
+                                     'admin_password'    => 'mypassword',
+                                     'concurrent_builds' => false,
+                                     'pipelines'         => [{
+                                                              'name'             => 'Baz Test',
+                                                              'git_url'          => 'git@github.com:bar/baz.git',
+                                                              'git_ref'          => 'refs/heads/develop',
+                                                              'jenkinsfile_path' => 'Jenkinsfile.baz',
+                                                              'credential_id'    => 'gitkey',
+                                                              'keep_builds'      => 10,
+                                                              'remote_trigger'   => true,
+                                                              'parameters'       => "booleanParam {
+                                                                                       name('Flag')
+                                                                                       defaultValue(true)
+                                                                                       description('Boolean flag')
+                                                                                     }"
+                                                            },
+                                                            {
+                                                              'name'             => ' Répo foö  ',
+                                                              'git_url'          => 'git@example.com:org/repo.git',
+                                                              'git_ref'          => 'main',
+                                                              'jenkinsfile_path' => 'pipelines/Jenkinsfile.repo',
+                                                              'credential_id'    => 'mygitcred',
+                                                              'keep_builds'      => 2,
+                                                              'parameters'       => "stringParam {
+                                                                                       name('String')
+                                                                                       defaultValue('')
+                                                                                       description('String parameter example')
+                                                                                       trim(true)
+                                                                                     }
+                                                                                     booleanParam {
+                                                                                       name('Myflag')
+                                                                                       defaultValue(false)
+                                                                                       description('Boolean flag example')
+                                                                                     }"
+                                                            }]
+                                     }
             } }
 
             it { is_expected.to contain_file('job-dsl configuration').with_content(/^\s*pipelineJob\('baz-test'\)/) }

--- a/templates/jenkins/plugin/job-dsl.yaml.erb
+++ b/templates/jenkins/plugin/job-dsl.yaml.erb
@@ -27,7 +27,9 @@ jobs:<%- if @configuration['pipelines'].empty? -%> []
               copyArtifactPermissionProperty {
                   projectNames('*')
               }
+              <%- unless @configuration['concurrent_builds'] -%>
               disableConcurrentBuilds { abortPrevious(<%= pipeline['abort_previous'].nil? ? 'true' : pipeline['abort_previous'] %>) }
+              <%- end -%>
               pipelineTriggers {
                   triggers {
                     <%- if pipeline['auto_build'].is_a? TrueClass -%>

--- a/templates/jenkins/plugin/throttle-concurrents.yaml.erb
+++ b/templates/jenkins/plugin/throttle-concurrents.yaml.erb
@@ -1,0 +1,11 @@
+---
+unclassified:
+  <%- if @configuration['max_concurrent_builds'] == 1 -%>
+  throttleJobProperty: {}
+  <%- else -%>
+  throttleJobProperty:
+    categories:
+      - categoryName: "Concurrent"
+        maxConcurrentPerNode: 1
+        maxConcurrentTotal: <%= @configuration['max_concurrent_builds'] %>
+  <%- end -%>


### PR DESCRIPTION
This is the controller configuration part of the concurrent builds. I deliberately kept it simple: one category, with one maximum of concurrent builds to be specified. As we mostly have deployment pipelines, it does not make sense for these to run concurrently. This is mostly for acceptance tests.

This needs some extra configuration in the job definition:

```
pipeline {
    agent any

    // Throttle a declarative pipeline via options
    options {
      throttleJobProperty(
          categories: ['test_3'],
          throttleEnabled: true,
          throttleOption: 'category'
      )
    }
    stages {
        stage('sleep') {
            steps {
                sh "sleep 500"
                echo "Done"
            }
        }
    }
}
```
or (for stage level agents):
```
pipeline {
    agent none

    stages {
        stage('sleep') {
            agent any
            options {
                throttle(['test_4'])
            }
            steps {
                sh "sleep 500"
                echo "Done"
            }
        }
    }
}
```



- **Add throttle-concurrents plugin and basic configuration with one category**
- **Add concurrent_builds parameter to job-dsl plugin configuration**
- **Add ability to specify allowed number of concurrent builds for a project in main Jenkins controller profile**
