### PR TITLE
Restart Apache periodically for UiT frontend

### DIFF
--- a/manifests/uit/frontend.pp
+++ b/manifests/uit/frontend.pp
@@ -53,8 +53,7 @@ class profiles::uit::frontend (
     user    => 'root',
     hour    => 2,
     minute  => 0,
-    weekday => '2,5',
-    require => Class['profiles::apache'],
+    weekday => [2, 5],
   }
 
   file { $basedir:

--- a/manifests/uit/frontend.pp
+++ b/manifests/uit/frontend.pp
@@ -47,6 +47,16 @@ class profiles::uit::frontend (
   include ::profiles::nodejs
   include ::profiles::apache
 
+  cron { 'uit-frontend-restart-apache':
+    ensure  => 'present',
+    command => '/bin/systemctl restart apache2',
+    user    => 'root',
+    hour    => 2,
+    minute  => 0,
+    weekday => '2,5',
+    require => Class['profiles::apache'],
+  }
+
   file { $basedir:
     ensure  => 'directory',
     owner   => 'www-data',

--- a/spec/classes/uit/frontend_spec.rb
+++ b/spec/classes/uit/frontend_spec.rb
@@ -38,6 +38,16 @@ describe 'profiles::uit::frontend' do
             it { is_expected.to contain_class('profiles::nodejs') }
             it { is_expected.to contain_class('profiles::apache') }
 
+            it { is_expected.to contain_cron('uit-frontend-restart-apache').with(
+              'ensure'  => 'present',
+              'command' => '/bin/systemctl restart apache2',
+              'user'    => 'root',
+              'hour'    => 2,
+              'minute'  => 0,
+              'weekday' => '2,5'
+            ) }
+            it { is_expected.to contain_cron('uit-frontend-restart-apache').that_requires('Class[profiles::apache]') }
+
             it { is_expected.to contain_file('/var/www/uit-frontend').with(
               'ensure' => 'directory',
               'owner'  => 'www-data',

--- a/spec/classes/uit/frontend_spec.rb
+++ b/spec/classes/uit/frontend_spec.rb
@@ -44,9 +44,8 @@ describe 'profiles::uit::frontend' do
               'user'    => 'root',
               'hour'    => 2,
               'minute'  => 0,
-              'weekday' => '2,5'
+              'weekday' => [2, 5]
             ) }
-            it { is_expected.to contain_cron('uit-frontend-restart-apache').that_requires('Class[profiles::apache]') }
 
             it { is_expected.to contain_file('/var/www/uit-frontend').with(
               'ensure' => 'directory',


### PR DESCRIPTION
### Added

- cronjob to restart Apache 2/week  to fix orphaned log file pointers which are kept open by apache

### Changed

-

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
