### PR TITLE
[OPS-1550_2]: add compose in docker profile

### DIFF
--- a/manifests/docker.pp
+++ b/manifests/docker.pp
@@ -52,6 +52,11 @@ class profiles::docker (
     require                     => Apt::Source['docker']
   }
 
+  class { 'docker::compose':
+    ensure  => present,
+    require => Class['docker']
+  }
+
   @profiles::jenkins::node_labels { 'docker':
     content => 'docker'
   }

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -32,6 +32,8 @@ describe 'profiles::docker' do
           'docker_users'                => []
         ) }
 
+        it { is_expected.to contain_class('docker::compose') }
+
         it { is_expected.not_to contain_profiles__jenkins__node_labels('docker') }
 
         it { is_expected.to_not contain_profiles__lvm__mount('dockerdata') }
@@ -69,6 +71,7 @@ describe 'profiles::docker' do
         ) }
 
         it { is_expected.to contain_apt__source('docker').that_comes_before('Class[docker]') }
+        it { is_expected.to contain_class('docker::compose').that_requires('Class[docker]') }
         it { is_expected.to contain_file('/var/lib/docker').that_comes_before('Class[docker]') }
         it { is_expected.to contain_class('profiles::docker::ecr_login').that_requires('Class[docker]') }
 


### PR DESCRIPTION
### Added

- Compose wasn't included in the docker profile. This will add it to every node using the profile

### Changed

-

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
