### PR TITLE
[OPS-1550_3]: support environment specific tag in facts and profile

### DIFF
--- a/lib/facter/docker_image_tag.rb
+++ b/lib/facter/docker_image_tag.rb
@@ -3,14 +3,16 @@ Facter.add('docker_image_tag') do
     repos = Facter.value('docker_ecr_repos')
     next nil unless repos.is_a?(Hash) && !repos.empty?
 
-    repos.each_with_object({}) do |(name, region), result|
-      region ||= 'eu-west-1'
+    repos.each_with_object({}) do |(name, config), result|
+      region    = config['region']    || 'eu-west-1'
+      image_tag = config['image_tag'] || 'latest'
+
       output = Facter::Core::Execution.execute(
         "aws ecr describe-images \
           --repository-name #{name} \
-          --image-ids imageTag=latest \
+          --image-ids imageTag=#{image_tag} \
           --region #{region} \
-          --query \"imageDetails[0].imageTags[?!= 'latest'] | [0]\" \
+          --query \"imageDetails[0].imageTags[?!= '#{image_tag}'] | [0]\" \
           --output text",
         on_fail: nil
       )

--- a/manifests/docker/ecr_repos.pp
+++ b/manifests/docker/ecr_repos.pp
@@ -1,5 +1,5 @@
 class profiles::docker::ecr_repos (
-  Hash[String, String] $repos = {}
+  Hash[String, Hash] $repos = {}
 ) inherits ::profiles {
 
   realize File['/etc/puppetlabs/facter/facts.d']


### PR DESCRIPTION
### Added

-To support image tag promotion across environments, we should always use an env-specific tag instead of latest in the fact.

### Changed

-

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
