### PR TITLE
[OPS-1550_8]: rename mime-support package for ubuntu 24.04+

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -53,7 +53,13 @@ class profiles::apache (
 
   include profiles::apache::logging
 
+  $mime_support_package = $facts['os']['release']['major'] ? {
+    '20.04' => 'mime-support',
+    default => 'media-types',
+  }
+
   class { "apache::mod::mime":
+    mime_support_package  => $mime_support_package,
     mime_types_additional => {
       'AddType' => { 'image/webp' => '.webp' }
     }

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -50,6 +50,10 @@ describe 'profiles::apache' do
 
         it { is_expected.to contain_group('www-data').that_comes_before('Class[apache]') }
         it { is_expected.to contain_user('www-data').that_comes_before('Class[apache]') }
+
+        it { is_expected.to contain_class('apache::mod::mime').with(
+          'mime_support_package' => 'mime-support'
+        ) }
       end
 
       context "with mpm_module => worker, mpm_module_config => { startservers => 8, maxrequestworkers => 256 }, http2 => true, limitreqfieldsize => 32766, service_status => stopped and metrics => false" do
@@ -96,6 +100,18 @@ describe 'profiles::apache' do
         } }
 
         it { expect { catalogue }.to raise_error(Puppet::ParseError, /The HTTP\/2 protocol is not supported with MPM module prefork/) }
+      end
+    end
+
+    context "on ubuntu-24.04" do
+      let(:facts) { facts.merge({ os: facts[:os].merge({ 'release' => facts[:os]['release'].merge({ 'major' => '24.04', 'full' => '24.04' }) }) }) }
+
+      context "without parameters" do
+        it { is_expected.to compile.with_all_deps }
+
+        it { is_expected.to contain_class('apache::mod::mime').with(
+          'mime_support_package' => 'media-types'
+        ) }
       end
     end
   end


### PR DESCRIPTION
### Added

- Rename mime-support package for ubuntu 24.04.
Based on this error during puppet run on the new node with ubuntu 24.04:
```
Package mime-support is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  media-types mailcap
```

### Changed

-

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
