### PR TITLE
[test-fix]: attempt: Replace $basedir symlink for facet_mapping_regio…

### DIFF
--- a/manifests/uitdatabank/search_api/deployment/instance.pp
+++ b/manifests/uitdatabank/search_api/deployment/instance.pp
@@ -27,6 +27,12 @@ class profiles::uitdatabank::search_api::deployment::instance (
     *      => $file_default_attributes
   }
 
+  file { "${config_dir}/facet_mapping_regions.php":
+    ensure => 'link',
+    target => '/var/www/geojson-data/output/facet_mapping_regions.php',
+    *      => $file_default_attributes
+  }
+
   file { "${basedir}/facet_mapping_regions.php":
     ensure => 'link',
     target => '/var/www/geojson-data/output/facet_mapping_regions.php',


### PR DESCRIPTION
…ns.php with $config_dir, since config.php is also a symlink and PHP resolves __DIR__ to the real path /etc/uitdatabank-search-api, causing the facet mapping lookup to fail silently.

### Added

-

### Changed

-

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
