### PR TITLE
[OPS-1550_12]: container deployment setup for udb-backend

### DIFF
--- a/manifests/uitdatabank/entry_api/deployment/container.pp
+++ b/manifests/uitdatabank/entry_api/deployment/container.pp
@@ -1,0 +1,155 @@
+class profiles::uitdatabank::entry_api::deployment::container (
+  String           $image,
+  String           $config_source,
+  String           $admin_permissions_source,
+  String           $client_permissions_source,
+  String           $movie_fetcher_config_source,
+  String           $completeness_source,
+  String           $externalid_mapping_organizer_source,
+  String           $externalid_mapping_place_source,
+  String           $pubkey_uitidv1_source,
+  String           $pubkey_keycloak_source,
+  String           $aws_region                                    = 'eu-west-1',
+  Optional[String] $image_tag                                     = undef,
+  Optional[String] $api_keys_matched_to_client_ids_source         = undef,
+  Enum['present', 'absent'] $amqp_listener_uitpas                 = 'present',
+  Enum['present', 'absent'] $bulk_label_offer_worker              = 'present',
+  Enum['present', 'absent'] $mail_worker                          = 'present',
+  Integer[0]                $event_export_worker_count            = 1,
+) inherits ::profiles {
+  $config_dir         = '/etc/uitdatabank-entry-api'
+  $basedir            = '/var/www/udb3-backend'
+  $webroot            = "${basedir}/web"
+  $secrets            = lookup('vault:uitdatabank/udb3-backend')
+  $ecr_repository     = regsubst($image, '^[^/]+/', '')
+  $resolved_image_tag = pick($image_tag, $facts.dig('docker_image_tag', $ecr_repository), 'latest')
+
+  $file_default_attributes = {
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0640',
+    require => File[$config_dir],
+    notify  => Exec['uitdatabank-entry-api-docker-compose'],
+  }
+
+  include profiles::docker
+
+  class { 'profiles::docker::ecr_repos':
+    repos => {
+      $ecr_repository => {
+        'region'    => $aws_region,
+        'image_tag' => $environment,
+      },
+    },
+  }
+
+  realize Group['www-data']
+  realize User['www-data']
+
+  file { $config_dir:
+    ensure => 'directory',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
+
+  file { 'uitdatabank-entry-api-config':
+    path    => "${config_dir}/config.php",
+    content => template($config_source),
+    *       => $file_default_attributes,
+  }
+
+  file { 'uitdatabank-entry-api-admin-permissions':
+    path    => "${config_dir}/config.allow_all.php",
+    content => template($admin_permissions_source),
+    *       => $file_default_attributes,
+  }
+
+  file { 'uitdatabank-entry-api-client-permissions':
+    path    => "${config_dir}/config.client_permissions.php",
+    content => template($client_permissions_source),
+    *       => $file_default_attributes,
+  }
+
+  file { 'uitdatabank-entry-api-movie-fetcher-config':
+    path    => "${config_dir}/config.kinepolis.php",
+    content => template($movie_fetcher_config_source),
+    *       => $file_default_attributes,
+  }
+
+  file { 'uitdatabank-entry-api-completeness':
+    path    => "${config_dir}/config.completeness.php",
+    content => template($completeness_source),
+    *       => $file_default_attributes,
+  }
+
+  file { 'uitdatabank-entry-api-externalid-mapping-organizer':
+    path    => "${config_dir}/config.externalid_mapping_organizer.php",
+    content => template($externalid_mapping_organizer_source),
+    *       => $file_default_attributes,
+  }
+
+  file { 'uitdatabank-entry-api-externalid-mapping-place':
+    path    => "${config_dir}/config.externalid_mapping_place.php",
+    content => template($externalid_mapping_place_source),
+    *       => $file_default_attributes,
+  }
+
+  file { 'uitdatabank-entry-api-pubkey-uitidv1':
+    path    => "${config_dir}/public-uitidv1.pem",
+    content => template($pubkey_uitidv1_source),
+    *       => $file_default_attributes,
+  }
+
+  file { 'uitdatabank-entry-api-pubkey-keycloak':
+    path    => "${config_dir}/public-keycloak.pem",
+    content => template($pubkey_keycloak_source),
+    *       => $file_default_attributes,
+  }
+
+  file { 'uitdatabank-entry-api-api-keys-matched-to-client-ids':
+    ensure  => $api_keys_matched_to_client_ids_source ? {
+      undef   => 'absent',
+      default => 'file',
+    },
+    path    => "${config_dir}/api_keys_matched_to_client_ids.php",
+    content => $api_keys_matched_to_client_ids_source ? {
+      undef   => undef,
+      default => template($api_keys_matched_to_client_ids_source),
+    },
+    *       => $file_default_attributes,
+  }
+
+  file { 'uitdatabank-entry-api-docker-compose':
+    ensure  => 'file',
+    path    => "${config_dir}/docker-compose.yml",
+    content => template('profiles/uitdatabank/entry_api/deployment/container/docker-compose.yml.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    require => File[$config_dir],
+    notify  => Exec['uitdatabank-entry-api-docker-compose'],
+  }
+
+  exec { 'uitdatabank-entry-api-docker-compose':
+    command     => "/usr/bin/docker compose -f ${config_dir}/docker-compose.yml up -d --remove-orphans",
+    refreshonly => true,
+    require     => [Class['profiles::docker'], File['uitdatabank-entry-api-docker-compose']],
+  }
+
+  file { $webroot:
+    ensure  => 'directory',
+    owner   => 'www-data',
+    group   => 'www-data',
+    require => [Group['www-data'], User['www-data']],
+  }
+
+  file { "${webroot}/.htaccess":
+    ensure  => 'file',
+    owner   => 'www-data',
+    group   => 'www-data',
+    content => "RewriteEngine On\nRewriteCond %{REQUEST_FILENAME} !-f\nRewriteRule ^ index.php [QSA,L]\n",
+    require => File[$webroot],
+  }
+}

--- a/manifests/uitdatabank/entry_api/deployment/container.pp
+++ b/manifests/uitdatabank/entry_api/deployment/container.pp
@@ -25,7 +25,6 @@ class profiles::uitdatabank::entry_api::deployment::container (
   $resolved_image_tag = pick($image_tag, $facts.dig('docker_image_tag', $ecr_repository), 'latest')
 
   $file_default_attributes = {
-    ensure  => 'file',
     owner   => 'root',
     group   => 'root',
     mode    => '0640',
@@ -55,54 +54,63 @@ class profiles::uitdatabank::entry_api::deployment::container (
   }
 
   file { 'uitdatabank-entry-api-config':
+    ensure  => 'file',
     path    => "${config_dir}/config.php",
     content => template($config_source),
     *       => $file_default_attributes,
   }
 
   file { 'uitdatabank-entry-api-admin-permissions':
+    ensure  => 'file',
     path    => "${config_dir}/config.allow_all.php",
     content => template($admin_permissions_source),
     *       => $file_default_attributes,
   }
 
   file { 'uitdatabank-entry-api-client-permissions':
+    ensure  => 'file',
     path    => "${config_dir}/config.client_permissions.php",
     content => template($client_permissions_source),
     *       => $file_default_attributes,
   }
 
   file { 'uitdatabank-entry-api-movie-fetcher-config':
+    ensure  => 'file',
     path    => "${config_dir}/config.kinepolis.php",
     content => template($movie_fetcher_config_source),
     *       => $file_default_attributes,
   }
 
   file { 'uitdatabank-entry-api-completeness':
+    ensure  => 'file',
     path    => "${config_dir}/config.completeness.php",
     content => template($completeness_source),
     *       => $file_default_attributes,
   }
 
   file { 'uitdatabank-entry-api-externalid-mapping-organizer':
+    ensure  => 'file',
     path    => "${config_dir}/config.externalid_mapping_organizer.php",
     content => template($externalid_mapping_organizer_source),
     *       => $file_default_attributes,
   }
 
   file { 'uitdatabank-entry-api-externalid-mapping-place':
+    ensure  => 'file',
     path    => "${config_dir}/config.externalid_mapping_place.php",
     content => template($externalid_mapping_place_source),
     *       => $file_default_attributes,
   }
 
   file { 'uitdatabank-entry-api-pubkey-uitidv1':
+    ensure  => 'file',
     path    => "${config_dir}/public-uitidv1.pem",
     content => template($pubkey_uitidv1_source),
     *       => $file_default_attributes,
   }
 
   file { 'uitdatabank-entry-api-pubkey-keycloak':
+    ensure  => 'file',
     path    => "${config_dir}/public-keycloak.pem",
     content => template($pubkey_keycloak_source),
     *       => $file_default_attributes,

--- a/spec/classes/uitdatabank/entry_api/deployment/container_spec.rb
+++ b/spec/classes/uitdatabank/entry_api/deployment/container_spec.rb
@@ -1,0 +1,164 @@
+describe 'profiles::uitdatabank::entry_api::deployment::container' do
+  include_examples 'operating system support'
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+      let(:pre_condition) { 'realize(Group["www-data"], User["www-data"])' }
+
+      let(:required_params) { {
+        'image'                                  => 'registry.example.com/uitdatabank/entry-api',
+        'config_source'                          => 'appconfig/uitdatabank/udb3-backend/config.php',
+        'admin_permissions_source'               => 'appconfig/uitdatabank/udb3-backend/config.allow_all.php',
+        'client_permissions_source'              => 'appconfig/uitdatabank/udb3-backend/config.client_permissions.php',
+        'movie_fetcher_config_source'            => 'appconfig/uitdatabank/udb3-backend/config.kinepolis.php',
+        'completeness_source'                    => 'appconfig/uitdatabank/udb3-backend/config.completeness.php',
+        'externalid_mapping_organizer_source'    => 'appconfig/uitdatabank/udb3-backend/config.external_id_mapping_organizer.php',
+        'externalid_mapping_place_source'        => 'appconfig/uitdatabank/udb3-backend/config.external_id_mapping_place.php',
+        'pubkey_uitidv1_source'                  => 'appconfig/uitdatabank/keys/public.pem',
+        'pubkey_keycloak_source'                 => 'appconfig/uitdatabank/keys/pubkey-keycloak.pem'
+      } }
+
+      context 'with required parameters' do
+        let(:params) { required_params }
+
+        context 'in the acceptance environment' do
+          let(:environment) { 'acceptance' }
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+          it { is_expected.to compile.with_all_deps }
+
+          it { is_expected.to contain_class('profiles::uitdatabank::entry_api::deployment::container').with(
+            'image'                          => 'registry.example.com/uitdatabank/entry-api',
+            'aws_region'                     => 'eu-west-1',
+            'image_tag'                      => nil,
+            'api_keys_matched_to_client_ids_source' => nil,
+            'amqp_listener_uitpas'           => 'present',
+            'bulk_label_offer_worker'        => 'present',
+            'mail_worker'                    => 'present',
+            'event_export_worker_count'      => 1
+          ) }
+
+          it { is_expected.to contain_class('profiles::docker') }
+
+          it { is_expected.to contain_class('profiles::docker::ecr_repos').with(
+            'repos' => {
+              'uitdatabank/entry-api' => {
+                'region'    => 'eu-west-1',
+                'image_tag' => 'acceptance'
+              }
+            }
+          ) }
+
+          it { is_expected.to contain_file('/etc/uitdatabank-entry-api').with(
+            'ensure' => 'directory',
+            'owner'  => 'root',
+            'group'  => 'root',
+            'mode'   => '0755'
+          ) }
+
+          [
+            'uitdatabank-entry-api-config',
+            'uitdatabank-entry-api-admin-permissions',
+            'uitdatabank-entry-api-client-permissions',
+            'uitdatabank-entry-api-movie-fetcher-config',
+            'uitdatabank-entry-api-completeness',
+            'uitdatabank-entry-api-externalid-mapping-organizer',
+            'uitdatabank-entry-api-externalid-mapping-place',
+            'uitdatabank-entry-api-pubkey-uitidv1',
+            'uitdatabank-entry-api-pubkey-keycloak'
+          ].each do |file_resource|
+            it { is_expected.to contain_file(file_resource).with(
+              'ensure' => 'file',
+              'owner'  => 'root',
+              'group'  => 'root',
+              'mode'   => '0640'
+            ) }
+          end
+
+          it { is_expected.to contain_file('uitdatabank-entry-api-api-keys-matched-to-client-ids').with(
+            'ensure' => 'absent'
+          ) }
+
+          it { is_expected.to contain_file('uitdatabank-entry-api-docker-compose').with(
+            'ensure' => 'file',
+            'path'   => '/etc/uitdatabank-entry-api/docker-compose.yml',
+            'owner'  => 'root',
+            'group'  => 'root',
+            'mode'   => '0644'
+          ) }
+
+          it { is_expected.to contain_exec('uitdatabank-entry-api-docker-compose').with(
+            'command'     => '/usr/bin/docker compose -f /etc/uitdatabank-entry-api/docker-compose.yml up -d --remove-orphans',
+            'refreshonly' => true
+          ) }
+
+          it { is_expected.to contain_file('uitdatabank-entry-api-docker-compose').that_notifies('Exec[uitdatabank-entry-api-docker-compose]') }
+
+          it { is_expected.to contain_file('/var/www/udb3-backend/web').with(
+            'ensure' => 'directory',
+            'owner'  => 'www-data',
+            'group'  => 'www-data'
+          ) }
+
+          it { is_expected.to contain_file('/var/www/udb3-backend/web/.htaccess').with(
+            'ensure' => 'file',
+            'owner'  => 'www-data',
+            'group'  => 'www-data'
+          ) }
+
+          it { is_expected.to contain_file('uitdatabank-entry-api-docker-compose').with_content(/^\s+image: registry.example.com\/uitdatabank\/entry-api:latest$/) }
+          it { is_expected.to contain_file('uitdatabank-entry-api-docker-compose').with_content(/^\s+command: \["php", "vendor\/chrisboulton\/php-resque\/bin\/resque"\]$/) }
+          it { is_expected.to contain_file('uitdatabank-entry-api-docker-compose').with_content(/QUEUE: bulk_label_offer/) }
+          it { is_expected.to contain_file('uitdatabank-entry-api-docker-compose').with_content(/QUEUE: mails/) }
+          it { is_expected.to contain_file('uitdatabank-entry-api-docker-compose').with_content(/QUEUE: event_export/) }
+          it { is_expected.to contain_file('uitdatabank-entry-api-docker-compose').with_content(/\["php", "bin\/app.php", "amqp-listener:uitpas"\]/) }
+          it { is_expected.not_to contain_file('uitdatabank-entry-api-docker-compose').with_content(/api_keys_matched_to_client_ids/) }
+        end
+      end
+
+      context 'with image => myregistry.example.com/uitdatabank/entry-api, image_tag => foo, aws_region => us-east-1, api_keys_matched_to_client_ids_source set, amqp_listener_uitpas => absent, mail_worker => absent and event_export_worker_count => 2' do
+        let(:params) { required_params.merge({
+          'image'                                  => 'myregistry.example.com/uitdatabank/entry-api',
+          'image_tag'                              => 'foo',
+          'aws_region'                             => 'us-east-1',
+          'api_keys_matched_to_client_ids_source'  => 'appconfig/uitdatabank/udb3-backend/config.api_keys_matched_to_client_ids.php',
+          'amqp_listener_uitpas'                   => 'absent',
+          'mail_worker'                            => 'absent',
+          'event_export_worker_count'              => 2
+        }) }
+
+        context 'in the testing environment' do
+          let(:environment) { 'testing' }
+          let(:hiera_config) { 'spec/support/hiera/common.yaml' }
+
+          it { is_expected.to contain_class('profiles::docker::ecr_repos').with(
+            'repos' => {
+              'uitdatabank/entry-api' => {
+                'region'    => 'us-east-1',
+                'image_tag' => 'testing'
+              }
+            }
+          ) }
+
+          it { is_expected.to contain_file('uitdatabank-entry-api-api-keys-matched-to-client-ids').with(
+            'ensure' => 'file'
+          ) }
+
+          it { is_expected.to contain_file('uitdatabank-entry-api-docker-compose').with_content(/^\s+image: myregistry.example.com\/uitdatabank\/entry-api:foo$/) }
+          it { is_expected.to contain_file('uitdatabank-entry-api-docker-compose').with_content(/api_keys_matched_to_client_ids/) }
+          it { is_expected.not_to contain_file('uitdatabank-entry-api-docker-compose').with_content(/QUEUE: mails/) }
+          it { is_expected.not_to contain_file('uitdatabank-entry-api-docker-compose').with_content(/amqp-listener:uitpas/) }
+          it { is_expected.to contain_file('uitdatabank-entry-api-docker-compose').with_content(/event-export-worker-1/) }
+          it { is_expected.to contain_file('uitdatabank-entry-api-docker-compose').with_content(/event-export-worker-2/) }
+        end
+      end
+
+      context 'without image parameter' do
+        let(:params) { {} }
+
+        it { expect { catalogue }.to raise_error(Puppet::ParseError, /expects a value for parameter 'image'/) }
+      end
+    end
+  end
+end

--- a/templates/uitdatabank/entry_api/deployment/container/docker-compose.yml.erb
+++ b/templates/uitdatabank/entry_api/deployment/container/docker-compose.yml.erb
@@ -14,7 +14,7 @@ x-entry-api: &entry-api
     - /etc/uitdatabank-entry-api/config.externalid_mapping_place.php:/var/www/html/config.externalid_mapping_place.php:ro
     - /etc/uitdatabank-entry-api/public-uitidv1.pem:/var/www/html/public-uitidv1.pem:ro
     - /etc/uitdatabank-entry-api/public-keycloak.pem:/var/www/html/public-keycloak.pem:ro
-<% if @api_keys_matched_to_client_ids -%>
+<% if @api_keys_matched_to_client_ids_source -%>
     - /etc/uitdatabank-entry-api/api_keys_matched_to_client_ids.php:/var/www/html/api_keys_matched_to_client_ids.php:ro
 <% end -%>
 

--- a/templates/uitdatabank/entry_api/deployment/container/docker-compose.yml.erb
+++ b/templates/uitdatabank/entry_api/deployment/container/docker-compose.yml.erb
@@ -1,0 +1,79 @@
+x-entry-api: &entry-api
+  image: <%= @image %>:<%= @resolved_image_tag %>
+  network_mode: host
+  restart: unless-stopped
+  environment:
+    LOG_TO_STDOUT: "true"
+  volumes:
+    - /etc/uitdatabank-entry-api/config.php:/var/www/html/config.php:ro
+    - /etc/uitdatabank-entry-api/config.allow_all.php:/var/www/html/config.allow_all.php:ro
+    - /etc/uitdatabank-entry-api/config.client_permissions.php:/var/www/html/config.client_permissions.php:ro
+    - /etc/uitdatabank-entry-api/config.kinepolis.php:/var/www/html/config.kinepolis.php:ro
+    - /etc/uitdatabank-entry-api/config.completeness.php:/var/www/html/config.completeness.php:ro
+    - /etc/uitdatabank-entry-api/config.externalid_mapping_organizer.php:/var/www/html/config.externalid_mapping_organizer.php:ro
+    - /etc/uitdatabank-entry-api/config.externalid_mapping_place.php:/var/www/html/config.externalid_mapping_place.php:ro
+    - /etc/uitdatabank-entry-api/public-uitidv1.pem:/var/www/html/public-uitidv1.pem:ro
+    - /etc/uitdatabank-entry-api/public-keycloak.pem:/var/www/html/public-keycloak.pem:ro
+<% if @api_keys_matched_to_client_ids -%>
+    - /etc/uitdatabank-entry-api/api_keys_matched_to_client_ids.php:/var/www/html/api_keys_matched_to_client_ids.php:ro
+<% end -%>
+
+x-resque-worker: &resque-worker
+  <<: *entry-api
+  environment:
+    LOG_TO_STDOUT: "true"
+    APP_INCLUDE: /var/www/html/worker_bootstrap.php
+    INTERVAL: "1"
+    REDIS_BACKEND: "127.0.0.1:6379"
+
+services:
+  entry-api:
+    <<: *entry-api
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 9000 || exit 1"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+<% if @bulk_label_offer_worker == 'present' -%>
+  bulk-label-offer-worker:
+    <<: *resque-worker
+    command: ["php", "vendor/chrisboulton/php-resque/bin/resque"]
+    environment:
+      LOG_TO_STDOUT: "true"
+      APP_INCLUDE: /var/www/html/worker_bootstrap.php
+      INTERVAL: "1"
+      REDIS_BACKEND: "127.0.0.1:6379"
+      QUEUE: bulk_label_offer
+
+<% end -%>
+<% if @mail_worker == 'present' -%>
+  mail-worker:
+    <<: *resque-worker
+    command: ["php", "vendor/chrisboulton/php-resque/bin/resque"]
+    environment:
+      LOG_TO_STDOUT: "true"
+      APP_INCLUDE: /var/www/html/worker_bootstrap.php
+      INTERVAL: "1"
+      REDIS_BACKEND: "127.0.0.1:6379"
+      QUEUE: mails
+
+<% end -%>
+<% @event_export_worker_count.times do |i| -%>
+  event-export-worker-<%= i + 1 %>:
+    <<: *resque-worker
+    command: ["php", "vendor/chrisboulton/php-resque/bin/resque"]
+    environment:
+      LOG_TO_STDOUT: "true"
+      APP_INCLUDE: /var/www/html/worker_bootstrap.php
+      INTERVAL: "1"
+      REDIS_BACKEND: "127.0.0.1:6379"
+      QUEUE: event_export
+
+<% end -%>
+<% if @amqp_listener_uitpas == 'present' -%>
+  amqp-listener-uitpas:
+    <<: *entry-api
+    command: ["php", "bin/app.php", "amqp-listener:uitpas"]
+<% end -%>


### PR DESCRIPTION
### Added

- Puppet profile for container deployment of udb-backend. Unlike for udb-search, I didn't try to do the refactoring Kristof did, so there's a lot of duplication with deployment.pp. The advantage is not to touch profiles used in live machines (with the holidays season coming up I didn't want to risk it)

### Changed

-

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
