### PR TITLE
[OPS-1571]: cleanup old jira and confluence versions

### DIFF
--- a/lib/facter/confluence_installed_versions.rb
+++ b/lib/facter/confluence_installed_versions.rb
@@ -1,0 +1,11 @@
+Facter.add('confluence_installed_versions') do
+  confine kernel: 'Linux'
+  setcode do
+    next [] unless File.directory?('/opt/confluence')
+
+    Dir.glob('/opt/confluence/atlassian-confluence-[0-9]*')
+       .select { |dir| File.directory?(dir) }
+       .sort_by { |dir| -File.mtime(dir).to_i }
+       .map { |dir| File.basename(dir) }
+  end
+end

--- a/lib/facter/confluence_installed_versions.rb
+++ b/lib/facter/confluence_installed_versions.rb
@@ -5,7 +5,8 @@ Facter.add('confluence_installed_versions') do
 
     Dir.glob('/opt/confluence/atlassian-confluence-[0-9]*')
        .select { |dir| File.directory?(dir) }
-       .sort_by { |dir| -File.mtime(dir).to_i }
+       .sort_by { |path| Gem::Version.new(path[/^.*-(\d+\.\d+\.\d+)$/,1]) }
+       .reverse
        .map { |dir| File.basename(dir) }
   end
 end

--- a/lib/facter/jira_installed_versions.rb
+++ b/lib/facter/jira_installed_versions.rb
@@ -1,0 +1,11 @@
+Facter.add('jira_installed_versions') do
+  confine kernel: 'Linux'
+  setcode do
+    next [] unless File.directory?('/opt/jira')
+
+    Dir.glob('/opt/jira/atlassian-jira-software-[0-9]*-standalone')
+       .select { |dir| File.directory?(dir) }
+       .sort_by { |dir| -File.mtime(dir).to_i }
+       .map { |dir| File.basename(dir) }
+  end
+end

--- a/lib/facter/jira_installed_versions.rb
+++ b/lib/facter/jira_installed_versions.rb
@@ -5,7 +5,8 @@ Facter.add('jira_installed_versions') do
 
     Dir.glob('/opt/jira/atlassian-jira-software-[0-9]*-standalone')
        .select { |dir| File.directory?(dir) }
-       .sort_by { |dir| -File.mtime(dir).to_i }
+       .sort_by { |dir| Gem::Version.new(dir[/-(\d+\.\d+\.\d+)-standalone$/, 1]) }
+       .reverse
        .map { |dir| File.basename(dir) }
   end
 end

--- a/manifests/atlassian/confluence.pp
+++ b/manifests/atlassian/confluence.pp
@@ -12,7 +12,9 @@ class profiles::atlassian::confluence (
   Array                      $serveraliases     = [],
   Integer[17, 21]            $java_version      = 17,
   String                     $initial_heap_size = '1024m',
-  String                     $maximum_heap_size = '1024m'
+  String                     $maximum_heap_size = '1024m',
+  Boolean                    $cleanup_old_versions = false,
+  Integer[0]                 $versions_to_keep  = 1
 ) inherits ::profiles {
 
   $database_user = 'confluenceuser'
@@ -104,6 +106,20 @@ class profiles::atlassian::confluence (
                                  proxyPort => '443',
                                  scheme    => 'https'
                                }
+  }
+
+  if $cleanup_old_versions {
+    $confluence_current_version_dir = "atlassian-confluence-${version}"
+    $confluence_old_versions        = ($facts['confluence_installed_versions'].lest || { [] }) - [$confluence_current_version_dir]
+    $confluence_versions_to_remove  = $confluence_old_versions[$versions_to_keep, -1]
+
+    $confluence_versions_to_remove.each |String $old_version_dir| {
+      file { "/opt/confluence/${old_version_dir}":
+        ensure  => absent,
+        force   => true,
+        require => Class['confluence'],
+      }
+    }
   }
 
   file { $upm_configdir:

--- a/manifests/atlassian/jira.pp
+++ b/manifests/atlassian/jira.pp
@@ -13,7 +13,9 @@ class profiles::atlassian::jira (
   Array                      $serveraliases     = [],
   Integer[17, 21]            $java_version      = 17,
   String                     $initial_heap_size = '1024m',
-  String                     $maximum_heap_size = '1024m'
+  String                     $maximum_heap_size = '1024m',
+  Boolean                    $cleanup_old_versions = false,
+  Integer[0]                 $versions_to_keep  = 1
 ) inherits ::profiles {
 
   $database_user = 'jirauser'
@@ -134,6 +136,20 @@ class profiles::atlassian::jira (
                                 proxyPort => '443',
                                 scheme    => 'https'
                               }
+  }
+
+  if $cleanup_old_versions {
+    $jira_current_version_dir = "atlassian-jira-software-${version}-standalone"
+    $jira_old_versions        = ($facts['jira_installed_versions'].lest || { [] }) - [$jira_current_version_dir]
+    $jira_versions_to_remove  = $jira_old_versions[$versions_to_keep, -1]
+
+    $jira_versions_to_remove.each |String $old_version_dir| {
+      file { "/opt/jira/${old_version_dir}":
+        ensure  => absent,
+        force   => true,
+        require => Class['jira'],
+      }
+    }
   }
 
   file { 'Jira mysql-connector-j':

--- a/spec/classes/atlassian/confluence_spec.rb
+++ b/spec/classes/atlassian/confluence_spec.rb
@@ -47,6 +47,41 @@ describe 'profiles::atlassian::confluence' do
 
         it { is_expected.to contain_file("/home/confluence/upmconfig/truststore/#{certificate}").that_requires('File[/home/confluence/upmconfig/truststore]') }
       end
+
+      context 'with cleanup_old_versions disabled (default)' do
+        let(:facts) { facts.merge('confluence_installed_versions' => ['atlassian-confluence-9.2.1', 'atlassian-confluence-9.1.0']) }
+
+        it { is_expected.not_to contain_file('/opt/confluence/atlassian-confluence-9.1.0') }
+      end
+
+      context 'with cleanup_old_versions enabled' do
+        let(:params) { super().merge('cleanup_old_versions' => true) }
+        let(:facts) { facts.merge('confluence_installed_versions' => [
+          'atlassian-confluence-9.2.1',
+          'atlassian-confluence-9.1.0',
+          'atlassian-confluence-9.0.5'
+        ]) }
+
+        it { is_expected.to compile.with_all_deps }
+
+        it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-9.0.5').with(
+          'ensure' => 'absent',
+          'force'  => true
+        ).that_requires('Class[confluence]') }
+
+        # 9.1.0 is the one previous version kept for rollback (versions_to_keep defaults to 1)
+        it { is_expected.not_to contain_file('/opt/confluence/atlassian-confluence-9.1.0').with('ensure' => 'absent') }
+        # the current version must never be touched by cleanup
+        it { is_expected.not_to contain_file('/opt/confluence/atlassian-confluence-9.2.1').with('ensure' => 'absent') }
+
+        context 'with versions_to_keep set to 0' do
+          let(:params) { super().merge('versions_to_keep' => 0) }
+
+          it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-9.1.0').with('ensure' => 'absent') }
+          it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-9.0.5').with('ensure' => 'absent') }
+          it { is_expected.not_to contain_file('/opt/confluence/atlassian-confluence-9.2.1').with('ensure' => 'absent') }
+        end
+      end
     end
   end
 end

--- a/spec/classes/atlassian/jira_spec.rb
+++ b/spec/classes/atlassian/jira_spec.rb
@@ -1,0 +1,61 @@
+describe 'profiles::atlassian::jira' do
+  include_examples 'operating system support'
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      let(:pre_condition) { "volume_group { 'datavg': ensure => present }\nrealize Apt::Source['publiq-tools']\nrealize Package['mysql-connector-j']" }
+
+      let(:params) { {
+        'servername'        => 'jira.example.com',
+        'version'           => '10.3.7',
+        'java_opts'         => '-Djava.awt.headless=true',
+        'database_password' => 'secret',
+        'lvm'               => true,
+        'volume_group'      => 'datavg',
+        'volume_size'       => '40G'
+      } }
+
+      it { is_expected.to compile.with_all_deps }
+
+      context 'with cleanup_old_versions disabled (default)' do
+        let(:facts) { facts.merge('jira_installed_versions' => [
+          'atlassian-jira-software-10.3.7-standalone',
+          'atlassian-jira-software-10.3.6-standalone'
+        ]) }
+
+        it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-software-10.3.6-standalone').with('ensure' => 'absent') }
+      end
+
+      context 'with cleanup_old_versions enabled' do
+        let(:params) { super().merge('cleanup_old_versions' => true) }
+        let(:facts) { facts.merge('jira_installed_versions' => [
+          'atlassian-jira-software-10.3.7-standalone',
+          'atlassian-jira-software-10.3.6-standalone',
+          'atlassian-jira-software-10.3.5-standalone'
+        ]) }
+
+        it { is_expected.to compile.with_all_deps }
+
+        it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-10.3.5-standalone').with(
+          'ensure' => 'absent',
+          'force'  => true
+        ).that_requires('Class[jira]') }
+
+        # 10.3.6 is the one previous version kept for rollback (versions_to_keep defaults to 1)
+        it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-software-10.3.6-standalone').with('ensure' => 'absent') }
+        # the current version must never be touched by cleanup
+        it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-software-10.3.7-standalone').with('ensure' => 'absent') }
+
+        context 'with versions_to_keep set to 0' do
+          let(:params) { super().merge('versions_to_keep' => 0) }
+
+          it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-10.3.6-standalone').with('ensure' => 'absent') }
+          it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-10.3.5-standalone').with('ensure' => 'absent') }
+          it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-software-10.3.7-standalone').with('ensure' => 'absent') }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Added

Atlassian VM had disk space issues. I noticed that both /opt/Jira and /opt/confluence included several older versions, not used anymore and that were occupying disk space. 

This PR enables automating the older versions cleanup when a new version is installed

### Changed

-

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
