### PR TITLE
[OPS-1571]: add sessionTimeout and sessionEviction on Jenkins controller

### DIFF
--- a/manifests/jenkins/controller.pp
+++ b/manifests/jenkins/controller.pp
@@ -5,6 +5,7 @@ class profiles::jenkins::controller (
   Boolean                    $mfa                      = false,
   Boolean                    $role_based_authorization = false,
   Integer[1]                 $max_concurrent_builds    = 1,
+  Integer[1]                 $session_timeout_minutes  = 480,
   Boolean                    $lvm                      = false,
   Optional[String]           $volume_group             = undef,
   Optional[String]           $volume_size              = undef,
@@ -52,9 +53,10 @@ class profiles::jenkins::controller (
   }
 
   class { '::profiles::jenkins::controller::install':
-    version => $version,
-    require => Class['profiles::java'],
-    notify  => Class['profiles::jenkins::controller::service']
+    version                 => $version,
+    session_timeout_minutes => $session_timeout_minutes,
+    require                 => Class['profiles::java'],
+    notify                  => Class['profiles::jenkins::controller::service']
   }
 
   class { '::profiles::jenkins::controller::service':

--- a/manifests/jenkins/controller/install.pp
+++ b/manifests/jenkins/controller/install.pp
@@ -1,14 +1,19 @@
 class profiles::jenkins::controller::install (
-  String $version = 'latest'
+  String     $version                 = 'latest',
+  Integer[1] $session_timeout_minutes = 480
 ) inherits ::profiles {
 
-  $config_dir = '/var/lib/jenkins/casc_config'
-  $java_opts  = [
-                  '-Djava.awt.headless=true',
-                  '-Djenkins.install.runSetupWizard=false',
-                  "-Dcasc.jenkins.config=${config_dir}",
-                  '-Dhudson.cli.CLIAction.ACCEPT_URL_FROM_REQUEST=true'
-                ]
+  $config_dir   = '/var/lib/jenkins/casc_config'
+  $java_opts    = [
+    '-Djava.awt.headless=true',
+    '-Djenkins.install.runSetupWizard=false',
+    "-Dcasc.jenkins.config=${config_dir}",
+    '-Dhudson.cli.CLIAction.ACCEPT_URL_FROM_REQUEST=true',
+  ]
+  $jenkins_args = [
+    "--sessionTimeout=${session_timeout_minutes}",
+    "--sessionEviction=${session_timeout_minutes * 60}",
+  ]
 
   realize Group['jenkins']
   realize User['jenkins']
@@ -36,8 +41,16 @@ class profiles::jenkins::controller::install (
     require  => File['casc_config']
   }
 
+  shellvar { 'JENKINS_ARGS':
+    ensure   => 'present',
+    variable => 'JENKINS_ARGS',
+    target   => '/etc/default/jenkins',
+    value    => $jenkins_args.join(' '),
+    require  => File['casc_config']
+  }
+
   systemd::dropin_file { 'override.conf':
     unit    => 'jenkins.service',
-    content => "[Service]\nEnvironment=\"JAVA_OPTS=${java_opts.join(' ')}\""
+    content => "[Service]\nEnvironment=\"JAVA_OPTS=${java_opts.join(' ')}\"\nEnvironment=\"JENKINS_ARGS=${jenkins_args.join(' ')}\""
   }
 }

--- a/spec/classes/jenkins/controller/install_spec.rb
+++ b/spec/classes/jenkins/controller/install_spec.rb
@@ -11,7 +11,8 @@ describe 'profiles::jenkins::controller::install' do
         it { is_expected.to compile.with_all_deps }
 
         it { is_expected.to contain_class('profiles::jenkins::controller::install').with(
-          'version' => 'latest'
+          'version'                 => 'latest',
+          'session_timeout_minutes' => 480
         ) }
 
         it { is_expected.to contain_group('jenkins') }
@@ -37,14 +38,22 @@ describe 'profiles::jenkins::controller::install' do
           'value'    => '-Djava.awt.headless=true -Djenkins.install.runSetupWizard=false -Dcasc.jenkins.config=/var/lib/jenkins/casc_config -Dhudson.cli.CLIAction.ACCEPT_URL_FROM_REQUEST=true'
         ) }
 
+        it { is_expected.to contain_shellvar('JENKINS_ARGS').with(
+          'ensure'   => 'present',
+          'variable' => 'JENKINS_ARGS',
+          'target'   => '/etc/default/jenkins',
+          'value'    => '--sessionTimeout=480 --sessionEviction=28800'
+        ) }
+
         it { is_expected.to contain_systemd__dropin_file('override.conf').with(
           'unit'    => 'jenkins.service',
-          'content' => "[Service]\nEnvironment=\"JAVA_OPTS=-Djava.awt.headless=true -Djenkins.install.runSetupWizard=false -Dcasc.jenkins.config=/var/lib/jenkins/casc_config -Dhudson.cli.CLIAction.ACCEPT_URL_FROM_REQUEST=true\""
+          'content' => "[Service]\nEnvironment=\"JAVA_OPTS=-Djava.awt.headless=true -Djenkins.install.runSetupWizard=false -Dcasc.jenkins.config=/var/lib/jenkins/casc_config -Dhudson.cli.CLIAction.ACCEPT_URL_FROM_REQUEST=true\"\nEnvironment=\"JENKINS_ARGS=--sessionTimeout=480 --sessionEviction=28800\""
         ) }
 
         it { is_expected.to contain_file('casc_config').that_requires('User[jenkins]') }
         it { is_expected.to contain_file('casc_config').that_requires('Package[jenkins]') }
         it { is_expected.to contain_shellvar('JAVA_ARGS').that_requires('File[casc_config]') }
+        it { is_expected.to contain_shellvar('JENKINS_ARGS').that_requires('File[casc_config]') }
         it { is_expected.to contain_package('jenkins').that_requires('User[jenkins]') }
         it { is_expected.to contain_package('jenkins').that_requires('Apt::Source[publiq-jenkins]') }
       end
@@ -58,6 +67,18 @@ describe 'profiles::jenkins::controller::install' do
 
         it { is_expected.to contain_package('jenkins').with(
           'ensure' => '1.2.3'
+        ) }
+      end
+
+      context "with session_timeout_minutes => 120" do
+        let(:params) { {
+          'session_timeout_minutes' => 120
+        } }
+
+        it { is_expected.to compile.with_all_deps }
+
+        it { is_expected.to contain_shellvar('JENKINS_ARGS').with(
+          'value' => '--sessionTimeout=120 --sessionEviction=7200'
         ) }
       end
     end


### PR DESCRIPTION
Stackoverflow had a solution to our pain: https://stackoverflow.com/questions/26407541/increase-the-jenkins-login-timeout
Apparently the relevant flags are 2: 
> `sessionTimeout` is set in minutes; a user will be logged out after this time, no matter what. Default is 30 minutes.
> 
> `sessionEviction` is set in seconds; a user will be logged out after this time if their session is idle. Default is 30 minutes.

I set the default to 8 hours to both
