### PR TITLE
Fix env var name for Jenkins timeout

### DIFF
--- a/manifests/jenkins/controller/install.pp
+++ b/manifests/jenkins/controller/install.pp
@@ -11,7 +11,7 @@ class profiles::jenkins::controller::install (
     '-Dhudson.cli.CLIAction.ACCEPT_URL_FROM_REQUEST=true',
   ]
   $session_eviction_seconds = Integer($session_timeout_minutes) * 60
-  $jenkins_args = [
+  $jenkins_opts = [
     "--sessionTimeout=${session_timeout_minutes}",
     "--sessionEviction=${session_eviction_seconds}",
   ]
@@ -34,24 +34,13 @@ class profiles::jenkins::controller::install (
     require => Package['jenkins']
   }
 
-  shellvar { 'JAVA_ARGS':
-    ensure   => 'present',
-    variable => 'JAVA_ARGS',
-    target   => '/etc/default/jenkins',
-    value    => $java_opts.join(' '),
-    require  => File['casc_config']
-  }
-
-  shellvar { 'JENKINS_ARGS':
-    ensure   => 'present',
-    variable => 'JENKINS_ARGS',
-    target   => '/etc/default/jenkins',
-    value    => $jenkins_args.join(' '),
-    require  => File['casc_config']
+  file { '/etc/default/jenkins':
+    ensure  => absent,
+    require => Package['jenkins']
   }
 
   systemd::dropin_file { 'override.conf':
     unit    => 'jenkins.service',
-    content => "[Service]\nEnvironment=\"JAVA_OPTS=${java_opts.join(' ')}\"\nEnvironment=\"JENKINS_ARGS=${jenkins_args.join(' ')}\""
+    content => "[Service]\nEnvironment=\"JAVA_OPTS=${java_opts.join(' ')}\"\nEnvironment=\"JENKINS_OPTS=${jenkins_opts.join(' ')}\""
   }
 }

--- a/manifests/jenkins/controller/install.pp
+++ b/manifests/jenkins/controller/install.pp
@@ -10,7 +10,7 @@ class profiles::jenkins::controller::install (
     "-Dcasc.jenkins.config=${config_dir}",
     '-Dhudson.cli.CLIAction.ACCEPT_URL_FROM_REQUEST=true',
   ]
-  $session_eviction_seconds = Integer($session_timeout_minutes) * 60
+  $session_eviction_seconds = $session_timeout_minutes * 60
   $jenkins_opts = [
     "--sessionTimeout=${session_timeout_minutes}",
     "--sessionEviction=${session_eviction_seconds}",

--- a/spec/classes/jenkins/controller/install_spec.rb
+++ b/spec/classes/jenkins/controller/install_spec.rb
@@ -31,29 +31,18 @@ describe 'profiles::jenkins::controller::install' do
           'group'  => 'jenkins'
         ) }
 
-        it { is_expected.to contain_shellvar('JAVA_ARGS').with(
-          'ensure'   => 'present',
-          'variable' => 'JAVA_ARGS',
-          'target'   => '/etc/default/jenkins',
-          'value'    => '-Djava.awt.headless=true -Djenkins.install.runSetupWizard=false -Dcasc.jenkins.config=/var/lib/jenkins/casc_config -Dhudson.cli.CLIAction.ACCEPT_URL_FROM_REQUEST=true'
-        ) }
-
-        it { is_expected.to contain_shellvar('JENKINS_ARGS').with(
-          'ensure'   => 'present',
-          'variable' => 'JENKINS_ARGS',
-          'target'   => '/etc/default/jenkins',
-          'value'    => '--sessionTimeout=480 --sessionEviction=28800'
+        it { is_expected.to contain_file('/etc/default/jenkins').with(
+          'ensure' => 'absent'
         ) }
 
         it { is_expected.to contain_systemd__dropin_file('override.conf').with(
           'unit'    => 'jenkins.service',
-          'content' => "[Service]\nEnvironment=\"JAVA_OPTS=-Djava.awt.headless=true -Djenkins.install.runSetupWizard=false -Dcasc.jenkins.config=/var/lib/jenkins/casc_config -Dhudson.cli.CLIAction.ACCEPT_URL_FROM_REQUEST=true\"\nEnvironment=\"JENKINS_ARGS=--sessionTimeout=480 --sessionEviction=28800\""
+          'content' => "[Service]\nEnvironment=\"JAVA_OPTS=-Djava.awt.headless=true -Djenkins.install.runSetupWizard=false -Dcasc.jenkins.config=/var/lib/jenkins/casc_config -Dhudson.cli.CLIAction.ACCEPT_URL_FROM_REQUEST=true\"\nEnvironment=\"JENKINS_OPTS=--sessionTimeout=480 --sessionEviction=28800\""
         ) }
 
         it { is_expected.to contain_file('casc_config').that_requires('User[jenkins]') }
         it { is_expected.to contain_file('casc_config').that_requires('Package[jenkins]') }
-        it { is_expected.to contain_shellvar('JAVA_ARGS').that_requires('File[casc_config]') }
-        it { is_expected.to contain_shellvar('JENKINS_ARGS').that_requires('File[casc_config]') }
+        it { is_expected.to contain_file('/etc/default/jenkins').that_requires('Package[jenkins]') }
         it { is_expected.to contain_package('jenkins').that_requires('User[jenkins]') }
         it { is_expected.to contain_package('jenkins').that_requires('Apt::Source[publiq-jenkins]') }
       end
@@ -77,8 +66,8 @@ describe 'profiles::jenkins::controller::install' do
 
         it { is_expected.to compile.with_all_deps }
 
-        it { is_expected.to contain_shellvar('JENKINS_ARGS').with(
-          'value' => '--sessionTimeout=120 --sessionEviction=7200'
+        it { is_expected.to contain_systemd__dropin_file('override.conf').with(
+          'content' => /Environment="JENKINS_OPTS=--sessionTimeout=120 --sessionEviction=7200"/
         ) }
       end
     end


### PR DESCRIPTION
The flags passed to increase Jenkins' session timeout were being ignored. Looking at the controller's `/usr/bin/jenkins`, the env variable used is JENKINS_OPT and not JENKINS_ARGS.
I also cleaned-up the old shellvar setup to avoid confusion in the future.

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
