### PR TITLE
[OPS-1550_13]: replace  exec with a docker_compose resource after docker module upgrade

### DIFF
--- a/manifests/uitdatabank/search_api/deployment/container.pp
+++ b/manifests/uitdatabank/search_api/deployment/container.pp
@@ -30,13 +30,13 @@ class profiles::uitdatabank::search_api::deployment::container (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    notify  => Exec['uitdatabank-search-api-docker-compose'],
+    notify  => Docker_compose['uitdatabank-search-api'],
   }
 
-  exec { 'uitdatabank-search-api-docker-compose':
-    command     => "/usr/bin/docker compose -f ${config_dir}/docker-compose.yml up -d --remove-orphans",
-    refreshonly => true,
-    require     => [Class['profiles::docker'], File['uitdatabank-search-api-docker-compose']],
+  docker_compose { 'uitdatabank-search-api':
+    ensure        => present,
+    compose_files => ["${config_dir}/docker-compose.yml"],
+    require       => Class['profiles::docker'],
   }
 
   file { $webroot:
@@ -59,6 +59,6 @@ class profiles::uitdatabank::search_api::deployment::container (
     environment => ['MAILTO=infra+cron@publiq.be'],
     hour        => '0',
     minute      => '0',
-    require     => Exec['uitdatabank-search-api-docker-compose'],
+    require     => Docker_compose['uitdatabank-search-api'],
   }
 }

--- a/spec/classes/uitdatabank/search_api/deployment/container_spec.rb
+++ b/spec/classes/uitdatabank/search_api/deployment/container_spec.rb
@@ -54,9 +54,9 @@ describe 'profiles::uitdatabank::search_api::deployment::container' do
           it { is_expected.not_to contain_file('uitdatabank-search-api-docker-compose').with_content(/^\s+- \/etc\/uitdatabank-search-api\/default_queries.php:\/var\/www\/html\/default_queries.php:ro$/) }
           it { is_expected.not_to contain_file('uitdatabank-search-api-docker-compose').with_content(/^\s+- \/etc\/uitdatabank-search-api\/api_keys_matched_to_client_ids.php:\/var\/www\/html\/api_keys_matched_to_client_ids.php:ro$/) }
 
-          it { is_expected.to contain_exec('uitdatabank-search-api-docker-compose').with(
-            'command'     => '/usr/bin/docker compose -f /etc/uitdatabank-search-api/docker-compose.yml up -d --remove-orphans',
-            'refreshonly' => true
+          it { is_expected.to contain_docker_compose('uitdatabank-search-api').with(
+            'ensure'        => 'present',
+            'compose_files' => ['/etc/uitdatabank-search-api/docker-compose.yml']
           ) }
 
           it { is_expected.to contain_cron('uitdatabank-search-api-reindex-permanent').with(
@@ -66,8 +66,8 @@ describe 'profiles::uitdatabank::search_api::deployment::container' do
             'minute'      => '0'
           ) }
 
-          it { is_expected.to contain_file('uitdatabank-search-api-docker-compose').that_notifies('Exec[uitdatabank-search-api-docker-compose]') }
-          it { is_expected.to contain_cron('uitdatabank-search-api-reindex-permanent').that_requires('Exec[uitdatabank-search-api-docker-compose]') }
+          it { is_expected.to contain_file('uitdatabank-search-api-docker-compose').that_notifies('Docker_compose[uitdatabank-search-api]') }
+          it { is_expected.to contain_cron('uitdatabank-search-api-reindex-permanent').that_requires('Docker_compose[uitdatabank-search-api]') }
         end
       end
 


### PR DESCRIPTION
The upgraded docker module should support the `docker_compose` resource type: https://github.com/puppetlabs/puppetlabs-docker/pull/975
### Added

-

### Changed

-

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
