### PR TITLE
[OPS-1550_14]: add search-api docker container logs to centralized logging

### DIFF
--- a/files/uitdatabank/search_api/logstash_filter_app.conf
+++ b/files/uitdatabank/search_api/logstash_filter_app.conf
@@ -1,0 +1,6 @@
+mutate {
+  rename       => { "[host][name]" => "host" }
+  add_field    => { "[@metadata][log_type]" => "%{[fields][log_type]}" }
+  add_field    => { "[@metadata][environment]" => "%{[fields][environment]}" }
+  remove_field => ["beat", "tags", "source", "offset", "@version", "fields"]
+}

--- a/files/uitdatabank/search_api/logstash_filter_app.conf
+++ b/files/uitdatabank/search_api/logstash_filter_app.conf
@@ -1,6 +1,0 @@
-mutate {
-  rename       => { "[host][name]" => "host" }
-  add_field    => { "[@metadata][log_type]" => "%{[fields][log_type]}" }
-  add_field    => { "[@metadata][environment]" => "%{[fields][environment]}" }
-  remove_field => ["beat", "tags", "source", "offset", "@version", "fields"]
-}

--- a/manifests/uitdatabank/search_api/logging.pp
+++ b/manifests/uitdatabank/search_api/logging.pp
@@ -32,4 +32,26 @@ class profiles::uitdatabank::search_api::logging (
   # if $settings::storeconfigs {
   #   Profiles::Logstash::Filter_fragment <<| |>>
   # }
+
+  # Ships stdout/stderr from all search-api Docker containers on this host
+  # (search-api, search-consume-udb3-api/cli/related). No-op on hosts that
+  # don't run Docker containers, so it's safe to include unconditionally
+  # regardless of deployment type (instance vs container).
+  $app_log_type = 'uitdatabank::search_api::app'
+
+  filebeat::input { "${servername}_${app_log_type}":
+    input_type => 'docker',
+    doc_type   => 'log',
+    fields     => {
+      log_type    => $app_log_type,
+      environment => $environment,
+    },
+    require    => Class['profiles::filebeat'],
+  }
+
+  @@profiles::logstash::filter_fragment { "${servername}_${app_log_type}":
+    log_type => $app_log_type,
+    filter   => file('profiles/uitdatabank/search_api/logstash_filter_app.conf'),
+    tag      => $environment,
+  }
 }

--- a/manifests/uitdatabank/search_api/logging.pp
+++ b/manifests/uitdatabank/search_api/logging.pp
@@ -49,9 +49,10 @@ class profiles::uitdatabank::search_api::logging (
     require    => Class['profiles::filebeat'],
   }
 
-  @@profiles::logstash::filter_fragment { "${servername}_${app_log_type}":
-    log_type => $app_log_type,
-    filter   => file('profiles/uitdatabank/search_api/logstash_filter_app.conf'),
-    tag      => $environment,
-  }
+  # The corresponding Logstash filter/output for this log_type is
+  # hand-maintained directly in infrastructure's logs-prod01 filter.conf/
+  # output.conf, since the filter_fragment/concat collector mechanism used
+  # for the access log above is never actually realized on the logstash
+  # server (see the commented-out TODO). No fragment resource here to avoid
+  # a second copy that can drift from the real one.
 }

--- a/spec/classes/uitdatabank/search_api/logging_spec.rb
+++ b/spec/classes/uitdatabank/search_api/logging_spec.rb
@@ -51,11 +51,6 @@ describe 'profiles::uitdatabank::search_api::logging' do
                             }
           ) }
 
-          it { expect(exported_resources).to contain_profiles__logstash__filter_fragment('foo.example.com_uitdatabank::search_api::app').with(
-            'log_type' => 'uitdatabank::search_api::app',
-            'tag'      => 'acceptance'
-          ) }
-
           it { is_expected.to contain_filebeat__input('foo.example.com_uitdatabank::search_api::app').that_requires('Class[profiles::filebeat]') }
         end
       end
@@ -102,11 +97,6 @@ describe 'profiles::uitdatabank::search_api::logging' do
                               'log_type'    => 'uitdatabank::search_api::app',
                               'environment' => 'production'
                             }
-          ) }
-
-          it { expect(exported_resources).to contain_profiles__logstash__filter_fragment('bar.example.com_uitdatabank::search_api::app').with(
-            'log_type' => 'uitdatabank::search_api::app',
-            'tag'      => 'production'
           ) }
 
           it { is_expected.to contain_filebeat__input('bar.example.com_uitdatabank::search_api::app').that_requires('Class[profiles::filebeat]') }

--- a/spec/classes/uitdatabank/search_api/logging_spec.rb
+++ b/spec/classes/uitdatabank/search_api/logging_spec.rb
@@ -41,6 +41,22 @@ describe 'profiles::uitdatabank::search_api::logging' do
           ) }
 
           it { is_expected.to contain_filebeat__input('foo.example.com_uitdatabank::search_api::access').that_requires('Class[profiles::filebeat]') }
+
+          it { is_expected.to contain_filebeat__input('foo.example.com_uitdatabank::search_api::app').with(
+            'input_type' => 'docker',
+            'doc_type'   => 'log',
+            'fields'     => {
+                              'log_type'    => 'uitdatabank::search_api::app',
+                              'environment' => 'acceptance'
+                            }
+          ) }
+
+          it { expect(exported_resources).to contain_profiles__logstash__filter_fragment('foo.example.com_uitdatabank::search_api::app').with(
+            'log_type' => 'uitdatabank::search_api::app',
+            'tag'      => 'acceptance'
+          ) }
+
+          it { is_expected.to contain_filebeat__input('foo.example.com_uitdatabank::search_api::app').that_requires('Class[profiles::filebeat]') }
         end
       end
 
@@ -78,6 +94,22 @@ describe 'profiles::uitdatabank::search_api::logging' do
           ) }
 
           it { is_expected.to contain_filebeat__input('bar.example.com_uitdatabank::search_api::access').that_requires('Class[profiles::filebeat]') }
+
+          it { is_expected.to contain_filebeat__input('bar.example.com_uitdatabank::search_api::app').with(
+            'input_type' => 'docker',
+            'doc_type'   => 'log',
+            'fields'     => {
+                              'log_type'    => 'uitdatabank::search_api::app',
+                              'environment' => 'production'
+                            }
+          ) }
+
+          it { expect(exported_resources).to contain_profiles__logstash__filter_fragment('bar.example.com_uitdatabank::search_api::app').with(
+            'log_type' => 'uitdatabank::search_api::app',
+            'tag'      => 'production'
+          ) }
+
+          it { is_expected.to contain_filebeat__input('bar.example.com_uitdatabank::search_api::app').that_requires('Class[profiles::filebeat]') }
         end
       end
 

--- a/templates/uitdatabank/search_api/deployment/container/docker-compose.yml.erb
+++ b/templates/uitdatabank/search_api/deployment/container/docker-compose.yml.erb
@@ -4,6 +4,11 @@ x-search-service: &search-service
   restart: unless-stopped
   environment:
     LOG_TO_STDOUT: "true"
+  logging:
+    driver: json-file
+    options:
+      max-size: "10m"
+      max-file: "5"
   volumes:
     - /etc/uitdatabank-search-api/config.php:/var/www/html/config.php:ro
     - /etc/uitdatabank-search-api/public-keycloak.pem:/var/www/html/public-keycloak.pem:ro


### PR DESCRIPTION
Depends on https://github.com/cultuurnet/infrastructure/pull/1377

### Added

- Filebeat input for docker
- Logstash filter, following the same pattern as the existing apache access logs
- explicit logging config on the docker compose, capping local disk growth per container

### Changed

-

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
