### PR TITLE
Use real files instead of symlinks for UiTdatabank search API instance deployment configuration

### DIFF
--- a/manifests/uitdatabank/search_api/deployment.pp
+++ b/manifests/uitdatabank/search_api/deployment.pp
@@ -23,7 +23,8 @@ class profiles::uitdatabank::search_api::deployment (
 
       class { 'profiles::uitdatabank::search_api::deployment::instance':
         api_keys_matched_to_client_ids_source => $api_keys_matched_to_client_ids_source,
-        default_queries_source                => $default_queries_source
+        default_queries_source                => $default_queries_source,
+        require                               => Class['profiles::uitdatabank::search_api::deployment']
       }
 
       Class['profiles::php'] ~> Class['profiles::uitdatabank::search_api::deployment::instance']
@@ -32,7 +33,8 @@ class profiles::uitdatabank::search_api::deployment (
       class { 'profiles::uitdatabank::search_api::deployment::container':
         basedir                        => $basedir,
         api_keys_matched_to_client_ids => !!$api_keys_matched_to_client_ids_source,
-        default_queries                => !!$default_queries_source
+        default_queries                => !!$default_queries_source,
+        require                        => Class['profiles::uitdatabank::search_api::deployment']
       }
     }
   }
@@ -44,33 +46,29 @@ class profiles::uitdatabank::search_api::deployment (
     ensure => 'directory'
   }
 
-  file { 'uitdatabank-search-api-config':
+  file { "${config_dir}/config.php":
     ensure  => 'file',
-    path    => "${config_dir}/config.php",
     content => template($config_source),
     *       => $file_default_attributes
   }
 
-  file { 'uitdatabank-search-api-pubkey-keycloak':
+  file { "${config_dir}/public-keycloak.pem":
     ensure  => 'file',
-    path    => "${config_dir}/public-keycloak.pem",
     content => template($pubkey_keycloak_source),
     *       => $file_default_attributes
   }
 
-  file { 'uitdatabank-search-api-region-mapping':
+  file { "${config_dir}/mapping_region.json":
     ensure  => 'file',
-    path    => "${config_dir}/mapping_region.json",
     content => template($region_mapping_source),
     *       => $file_default_attributes
   }
 
-  file { 'uitdatabank-search-api-default-queries':
+  file { "${config_dir}/default_queries.php":
     ensure  => $default_queries_source ? {
                  undef   => 'absent',
                  default => 'file'
                },
-    path    => "${config_dir}/default_queries.php",
     content => $default_queries_source ? {
                  undef   => undef,
                  default => template($default_queries_source),
@@ -78,12 +76,11 @@ class profiles::uitdatabank::search_api::deployment (
     *       => $file_default_attributes
   }
 
-  file { 'uitdatabank-search-api-api-keys-matched-to-client-ids':
+  file { "${config_dir}/api_keys_matched_to_client_ids.php":
     ensure  => $api_keys_matched_to_client_ids_source ? {
                  undef   => 'absent',
                  default => 'file'
                },
-    path    => "${config_dir}/api_keys_matched_to_client_ids.php",
     content => $api_keys_matched_to_client_ids_source ? {
                  undef   => undef,
                  default => template($api_keys_matched_to_client_ids_source),

--- a/manifests/uitdatabank/search_api/deployment/instance.pp
+++ b/manifests/uitdatabank/search_api/deployment/instance.pp
@@ -9,9 +9,14 @@ class profiles::uitdatabank::search_api::deployment::instance (
   $basedir                 = '/var/www/udb3-search-service'
 
   $file_default_attributes = {
+                               owner   => 'www-data',
+                               group   => 'www-data',
                                require => Package['uitdatabank-search-api'],
                                notify  => [Service['uitdatabank-search-api'], Class['profiles::uitdatabank::search_api::listeners']]
                              }
+
+  realize Group['www-data']
+  realize User['www-data']
 
   realize Apt::Source[$repository]
 
@@ -22,56 +27,50 @@ class profiles::uitdatabank::search_api::deployment::instance (
   }
 
   file { "${basedir}/config.php":
-    ensure => 'link',
-    target => "${config_dir}/config.php",
-    *      => $file_default_attributes
-  }
-
-  file { "${config_dir}/facet_mapping_regions.php":
-    ensure => 'link',
-    target => '/var/www/geojson-data/output/facet_mapping_regions.php',
+    ensure => 'file',
+    source => "${config_dir}/config.php",
     *      => $file_default_attributes
   }
 
   file { "${basedir}/facet_mapping_regions.php":
-    ensure => 'link',
-    target => '/var/www/geojson-data/output/facet_mapping_regions.php',
+    ensure => 'file',
+    source => '/var/www/geojson-data/output/facet_mapping_regions.php',
     *      => $file_default_attributes
   }
 
   file { "${basedir}/web/autocomplete.json":
-    ensure => 'link',
-    target => '/var/www/geojson-data/output/autocomplete.json',
+    ensure => 'file',
+    source => '/var/www/geojson-data/output/autocomplete.json',
     *      => $file_default_attributes
   }
 
   file { "${basedir}/public-keycloak.pem":
-    ensure => 'link',
-    target => "${config_dir}/public-keycloak.pem",
+    ensure => 'file',
+    source => "${config_dir}/public-keycloak.pem",
     *      => $file_default_attributes
   }
 
   file { "${basedir}/src/ElasticSearch/Operations/json/mapping_region.json":
-    ensure => 'link',
-    target => "${config_dir}/mapping_region.json",
+    ensure => 'file',
+    source => "${config_dir}/mapping_region.json",
     *      => $file_default_attributes
   }
 
   file { "${basedir}/default_queries.php":
     ensure => $default_queries_source ? {
                  undef   => 'absent',
-                 default => 'link'
+                 default => 'file'
                },
-    target => "${config_dir}/default_queries.php",
+    source => "${config_dir}/default_queries.php",
     *      => $file_default_attributes
   }
 
   file { "${basedir}/api_keys_matched_to_client_ids.php":
     ensure => $api_keys_matched_to_client_ids_source ? {
                  undef   => 'absent',
-                 default => 'link'
+                 default => 'file'
                },
-    target => "${config_dir}/api_keys_matched_to_client_ids.php",
+    source => "${config_dir}/api_keys_matched_to_client_ids.php",
     *      => $file_default_attributes
   }
 

--- a/spec/classes/uitdatabank/search_api/deployment/instance_spec.rb
+++ b/spec/classes/uitdatabank/search_api/deployment/instance_spec.rb
@@ -17,6 +17,9 @@ describe 'profiles::uitdatabank::search_api::deployment::instance' do
           'api_keys_matched_to_client_ids_source' => nil
         ) }
 
+        it { is_expected.to contain_group('www-data') }
+        it { is_expected.to contain_user('www-data') }
+
         it { is_expected.to contain_apt__source('uitdatabank-search-api') }
 
         it { is_expected.to contain_package('uitdatabank-search-api').with(
@@ -43,38 +46,52 @@ describe 'profiles::uitdatabank::search_api::deployment::instance' do
         ) }
 
         it { is_expected.to contain_file('/var/www/udb3-search-service/config.php').with(
-          'ensure' => 'link',
-          'target' => '/etc/uitdatabank-search-api/config.php'
+          'ensure' => 'file',
+          'owner'  => 'www-data',
+          'group'  => 'www-data',
+          'source' => '/etc/uitdatabank-search-api/config.php'
         ) }
 
         it { is_expected.to contain_file('/var/www/udb3-search-service/facet_mapping_regions.php').with(
-          'ensure' => 'link',
-          'target' => '/var/www/geojson-data/output/facet_mapping_regions.php'
+          'ensure' => 'file',
+          'owner'  => 'www-data',
+          'group'  => 'www-data',
+          'source' => '/var/www/geojson-data/output/facet_mapping_regions.php'
         ) }
 
         it { is_expected.to contain_file('/var/www/udb3-search-service/web/autocomplete.json').with(
-          'ensure' => 'link',
-          'target' => '/var/www/geojson-data/output/autocomplete.json'
+          'ensure' => 'file',
+          'owner'  => 'www-data',
+          'group'  => 'www-data',
+          'source' => '/var/www/geojson-data/output/autocomplete.json'
         ) }
 
         it { is_expected.to contain_file('/var/www/udb3-search-service/src/ElasticSearch/Operations/json/mapping_region.json').with(
-          'ensure' => 'link',
-          'target' => '/etc/uitdatabank-search-api/mapping_region.json'
+          'ensure' => 'file',
+          'owner'  => 'www-data',
+          'group'  => 'www-data',
+          'source' => '/etc/uitdatabank-search-api/mapping_region.json'
         ) }
 
         it { is_expected.to contain_file('/var/www/udb3-search-service/default_queries.php').with(
           'ensure' => 'absent',
-          'target' => '/etc/uitdatabank-search-api/default_queries.php'
+          'owner'  => 'www-data',
+          'group'  => 'www-data',
+          'source' => '/etc/uitdatabank-search-api/default_queries.php'
         ) }
 
         it { is_expected.to contain_file('/var/www/udb3-search-service/api_keys_matched_to_client_ids.php').with(
           'ensure' => 'absent',
-          'target' => '/etc/uitdatabank-search-api/api_keys_matched_to_client_ids.php'
+          'owner'  => 'www-data',
+          'group'  => 'www-data',
+          'source' => '/etc/uitdatabank-search-api/api_keys_matched_to_client_ids.php'
         ) }
 
         it { is_expected.to contain_file('/var/www/udb3-search-service/public-keycloak.pem').with(
-          'ensure' => 'link',
-          'target' => '/etc/uitdatabank-search-api/public-keycloak.pem',
+          'ensure' => 'file',
+          'owner'  => 'www-data',
+          'group'  => 'www-data',
+          'source' => '/etc/uitdatabank-search-api/public-keycloak.pem'
           ) }
 
         it { is_expected.to contain_package('uitdatabank-search-api').that_requires('Apt::Source[uitdatabank-search-api]') }
@@ -122,13 +139,17 @@ describe 'profiles::uitdatabank::search_api::deployment::instance' do
           ) }
 
           it { is_expected.to contain_file('/var/www/udb3-search-service/api_keys_matched_to_client_ids.php').with(
-            'ensure' => 'link',
-            'target' => '/etc/uitdatabank-search-api/api_keys_matched_to_client_ids.php',
+            'ensure' => 'file',
+            'owner'  => 'www-data',
+            'group'  => 'www-data',
+            'source' => '/etc/uitdatabank-search-api/api_keys_matched_to_client_ids.php'
           ) }
 
           it { is_expected.to contain_file('/var/www/udb3-search-service/default_queries.php').with(
-            'ensure' => 'link',
-            'target' => '/etc/uitdatabank-search-api/default_queries.php',
+            'ensure' => 'file',
+            'owner'  => 'www-data',
+            'group'  => 'www-data',
+            'source' => '/etc/uitdatabank-search-api/default_queries.php'
           ) }
 
           it { is_expected.to contain_package('uitdatabank-search-api').that_requires('Apt::Source[foo]') }

--- a/spec/classes/uitdatabank/search_api/deployment_spec.rb
+++ b/spec/classes/uitdatabank/search_api/deployment_spec.rb
@@ -28,66 +28,64 @@ describe 'profiles::uitdatabank::search_api::deployment' do
           it { is_expected.to contain_group('www-data') }
           it { is_expected.to contain_user('www-data') }
 
-          it { is_expected.to contain_class('Profiles::Uitdatabank::Search_api::Deployment::Instance').with(
+          it { is_expected.to contain_class('profiles::uitdatabank::search_api::deployment::instance').with(
             'default_queries_source'                => nil,
             'api_keys_matched_to_client_ids_source' => nil
           ) }
 
-          it { is_expected.not_to contain_class('Profiles::Uitdatabank::Search_api::Deployment::Container') }
+          it { is_expected.not_to contain_class('profiles::uitdatabank::search_api::deployment::container') }
 
-          it { is_expected.to contain_file('uitdatabank-search-api-config').with(
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/config.php').with(
             'ensure'  => 'file',
             'owner'   => 'www-data',
             'group'   => 'www-data',
-            'path'    => '/etc/uitdatabank-search-api/config.php',
             'content' => ''
           ) }
 
-          it { is_expected.to contain_file('uitdatabank-search-api-api-keys-matched-to-client-ids').with(
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/api_keys_matched_to_client_ids.php').with(
             'ensure'  => 'absent',
             'owner'   => 'www-data',
-            'group'   => 'www-data',
-            'path'    => '/etc/uitdatabank-search-api/api_keys_matched_to_client_ids.php'
+            'group'   => 'www-data'
           ) }
 
-          it { is_expected.to contain_file('uitdatabank-search-api-region-mapping').with(
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/mapping_region.json').with(
             'ensure'  => 'file',
             'owner'   => 'www-data',
             'group'   => 'www-data',
-            'path'    => '/etc/uitdatabank-search-api/mapping_region.json',
             'content' => "{ \"properties\": {} }\n"
           ) }
 
-          it { is_expected.to contain_file('uitdatabank-search-api-default-queries').with(
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/default_queries.php').with(
             'ensure'  => 'absent',
             'owner'   => 'www-data',
-            'group'   => 'www-data',
-            'path'    => '/etc/uitdatabank-search-api/default_queries.php'
+            'group'   => 'www-data'
           ) }
 
-          it { is_expected.to contain_file('uitdatabank-search-api-pubkey-keycloak').with(
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/public-keycloak.pem').with(
             'ensure'  => 'file',
             'owner'   => 'www-data',
             'group'   => 'www-data',
-            'path'    => '/etc/uitdatabank-search-api/public-keycloak.pem',
             'content' => "uitdatabank keycloak public key\n"
           ) }
 
-          it { is_expected.to contain_file('uitdatabank-search-api-config').that_requires('Group[www-data]') }
-          it { is_expected.to contain_file('uitdatabank-search-api-config').that_requires('User[www-data]') }
-          it { is_expected.to contain_file('uitdatabank-search-api-config').that_notifies('Class[profiles::uitdatabank::search_api::deployment::instance]') }
-          it { is_expected.to contain_file('uitdatabank-search-api-region-mapping').that_requires('Group[www-data]') }
-          it { is_expected.to contain_file('uitdatabank-search-api-region-mapping').that_requires('User[www-data]') }
-          it { is_expected.to contain_file('uitdatabank-search-api-region-mapping').that_notifies('Class[profiles::uitdatabank::search_api::deployment::instance]') }
-          it { is_expected.to contain_file('uitdatabank-search-api-default-queries').that_requires('Group[www-data]') }
-          it { is_expected.to contain_file('uitdatabank-search-api-default-queries').that_requires('User[www-data]') }
-          it { is_expected.to contain_file('uitdatabank-search-api-default-queries').that_notifies('Class[profiles::uitdatabank::search_api::deployment::instance]') }
-          it { is_expected.to contain_file('uitdatabank-search-api-api-keys-matched-to-client-ids').that_requires('Group[www-data]') }
-          it { is_expected.to contain_file('uitdatabank-search-api-api-keys-matched-to-client-ids').that_requires('User[www-data]') }
-          it { is_expected.to contain_file('uitdatabank-search-api-api-keys-matched-to-client-ids').that_notifies('Class[profiles::uitdatabank::search_api::deployment::instance]') }
-          it { is_expected.to contain_file('uitdatabank-search-api-pubkey-keycloak').that_requires('Group[www-data]') }
-          it { is_expected.to contain_file('uitdatabank-search-api-pubkey-keycloak').that_requires('User[www-data]') }
-          it { is_expected.to contain_file('uitdatabank-search-api-pubkey-keycloak').that_notifies('Class[profiles::uitdatabank::search_api::deployment::instance]') }
+          it { is_expected.to contain_class('profiles::uitdatabank::search_api::deployment::instance').that_requires('Class[profiles::php]') }
+          it { is_expected.to contain_class('profiles::uitdatabank::search_api::deployment::instance').that_requires('Class[profiles::uitdatabank::search_api::deployment]') }
+
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/config.php').that_requires('Group[www-data]') }
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/config.php').that_requires('User[www-data]') }
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/config.php').that_notifies('Class[profiles::uitdatabank::search_api::deployment::instance]') }
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/mapping_region.json').that_requires('Group[www-data]') }
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/mapping_region.json').that_requires('User[www-data]') }
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/mapping_region.json').that_notifies('Class[profiles::uitdatabank::search_api::deployment::instance]') }
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/default_queries.php').that_requires('Group[www-data]') }
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/default_queries.php').that_requires('User[www-data]') }
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/default_queries.php').that_notifies('Class[profiles::uitdatabank::search_api::deployment::instance]') }
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/api_keys_matched_to_client_ids.php').that_requires('Group[www-data]') }
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/api_keys_matched_to_client_ids.php').that_requires('User[www-data]') }
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/api_keys_matched_to_client_ids.php').that_notifies('Class[profiles::uitdatabank::search_api::deployment::instance]') }
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/public-keycloak.pem').that_requires('Group[www-data]') }
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/public-keycloak.pem').that_requires('User[www-data]') }
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/public-keycloak.pem').that_notifies('Class[profiles::uitdatabank::search_api::deployment::instance]') }
         end
 
         context "with type => container, config_source => appconfig/uitdatabank/udb3-search-service/myconfig.php, pubkey_keycloak_source => appconfig/uitdatabank/keys/mypubkey-keycloak.pem, region_mapping_source => appconfig/uitdatabank/udb3-search-service/my_region_mapping.json, default_queries_source => appconfig/uitdatabank/udb3-search-service/default_queries.php and api_keys_matched_to_client_ids_source => appconfig/uitdatabank/udb3-search-service/api_keys.php" do
@@ -100,58 +98,55 @@ describe 'profiles::uitdatabank::search_api::deployment' do
             'api_keys_matched_to_client_ids_source' => 'appconfig/uitdatabank/udb3-search-service/api_keys.php'
           } }
 
-          it { is_expected.not_to contain_class('Profiles::Uitdatabank::Search_api::Deployment::Instance') }
+          it { is_expected.not_to contain_class('profiles::uitdatabank::search_api::deployment::instance') }
 
-          it { is_expected.to contain_class('Profiles::Uitdatabank::Search_api::Deployment::Container').with(
+          it { is_expected.to contain_class('profiles::uitdatabank::search_api::deployment::container').with(
             'api_keys_matched_to_client_ids' => true,
             'default_queries'                => true
           ) }
 
-          it { is_expected.to contain_file('uitdatabank-search-api-config').with(
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/config.php').with(
             'ensure'  => 'file',
             'owner'   => 'www-data',
             'group'   => 'www-data',
-            'path'    => '/etc/uitdatabank-search-api/config.php',
             'content' => "<?php\n\nreturn [];\n"
           ) }
 
-          it { is_expected.to contain_file('uitdatabank-search-api-api-keys-matched-to-client-ids').with(
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/api_keys_matched_to_client_ids.php').with(
             'ensure'  => 'file',
             'owner'   => 'www-data',
             'group'   => 'www-data',
-            'path'    => '/etc/uitdatabank-search-api/api_keys_matched_to_client_ids.php',
             'content' => ''
           ) }
 
-          it { is_expected.to contain_file('uitdatabank-search-api-region-mapping').with(
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/mapping_region.json').with(
             'ensure'  => 'file',
             'owner'   => 'www-data',
             'group'   => 'www-data',
-            'path'    => '/etc/uitdatabank-search-api/mapping_region.json',
             'content' => ''
           ) }
 
-          it { is_expected.to contain_file('uitdatabank-search-api-default-queries').with(
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/default_queries.php').with(
             'ensure'  => 'file',
             'owner'   => 'www-data',
             'group'   => 'www-data',
-            'path'    => '/etc/uitdatabank-search-api/default_queries.php',
             'content' => ''
           ) }
 
-          it { is_expected.to contain_file('uitdatabank-search-api-pubkey-keycloak').with(
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/public-keycloak.pem').with(
             'ensure'  => 'file',
             'owner'   => 'www-data',
             'group'   => 'www-data',
-            'path'    => '/etc/uitdatabank-search-api/public-keycloak.pem',
             'content' => ''
           ) }
 
-          it { is_expected.to contain_file('uitdatabank-search-api-config').that_notifies('Class[profiles::uitdatabank::search_api::deployment::container]') }
-          it { is_expected.to contain_file('uitdatabank-search-api-region-mapping').that_notifies('Class[profiles::uitdatabank::search_api::deployment::container]') }
-          it { is_expected.to contain_file('uitdatabank-search-api-default-queries').that_notifies('Class[profiles::uitdatabank::search_api::deployment::container]') }
-          it { is_expected.to contain_file('uitdatabank-search-api-api-keys-matched-to-client-ids').that_notifies('Class[profiles::uitdatabank::search_api::deployment::container]') }
-          it { is_expected.to contain_file('uitdatabank-search-api-pubkey-keycloak').that_notifies('Class[profiles::uitdatabank::search_api::deployment::container]') }
+          it { is_expected.to contain_class('profiles::uitdatabank::search_api::deployment::container').that_requires('Class[profiles::uitdatabank::search_api::deployment]') }
+
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/config.php').that_notifies('Class[profiles::uitdatabank::search_api::deployment::container]') }
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/mapping_region.json').that_notifies('Class[profiles::uitdatabank::search_api::deployment::container]') }
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/default_queries.php').that_notifies('Class[profiles::uitdatabank::search_api::deployment::container]') }
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/api_keys_matched_to_client_ids.php').that_notifies('Class[profiles::uitdatabank::search_api::deployment::container]') }
+          it { is_expected.to contain_file('/etc/uitdatabank-search-api/public-keycloak.pem').that_notifies('Class[profiles::uitdatabank::search_api::deployment::container]') }
         end
       end
 


### PR DESCRIPTION
Instead of using symlinks (which exhibit problems with the PHP code, more specifically `__DIR__` follows symlinks) I now use real files with a source attribute instead of a target attribute for the config files in the instance deployment. That way the PHP code will just work. I think it is more robust than other solutions as we can not be sure the developers will not add additional things like this in the future and I don't want to continuously police the config files.

The symlinks were used as the simplest solution to get the files in the right location for the instance deployment, starting from the new "canonical" source which is `/etc/uitdatabank-search-api`, so that we can prepare for container deployment as it also sources the files from the new canonical source, but with a different mechanism.

Having a real file resource in the instance deployment which points to the canonical source is nearly as good I think. It is a bit more involved as the files are copied, but:
1. puppet takes care of that so we don't need to worry about it
2. it will solve the symlink bug now and in the future and 
3. it's the legacy deployment anyway