### PR TITLE
[OPS-1550_14]: use generic log input instead of docker

### DIFF
--- a/manifests/uitdatabank/search_api/logging.pp
+++ b/manifests/uitdatabank/search_api/logging.pp
@@ -40,13 +40,18 @@ class profiles::uitdatabank::search_api::logging (
   $app_log_type = 'uitdatabank::search_api::app'
 
   filebeat::input { "${servername}_${app_log_type}":
-    input_type => 'docker',
-    doc_type   => 'log',
-    fields     => {
+    paths    => ['/var/lib/docker/containers/*/*-json.log'],
+    doc_type => 'log',
+    json     => {
+      keys_under_root => true,
+      message_key     => 'log',
+      add_error_key   => true,
+    },
+    fields   => {
       log_type    => $app_log_type,
       environment => $environment,
     },
-    require    => Class['profiles::filebeat'],
+    require  => Class['profiles::filebeat'],
   }
 
   # The corresponding Logstash filter/output for this log_type is

--- a/spec/classes/uitdatabank/search_api/logging_spec.rb
+++ b/spec/classes/uitdatabank/search_api/logging_spec.rb
@@ -43,12 +43,17 @@ describe 'profiles::uitdatabank::search_api::logging' do
           it { is_expected.to contain_filebeat__input('foo.example.com_uitdatabank::search_api::access').that_requires('Class[profiles::filebeat]') }
 
           it { is_expected.to contain_filebeat__input('foo.example.com_uitdatabank::search_api::app').with(
-            'input_type' => 'docker',
-            'doc_type'   => 'log',
-            'fields'     => {
-                              'log_type'    => 'uitdatabank::search_api::app',
-                              'environment' => 'acceptance'
-                            }
+            'paths'    => ['/var/lib/docker/containers/*/*-json.log'],
+            'doc_type' => 'log',
+            'json'     => {
+                            'keys_under_root' => true,
+                            'message_key'     => 'log',
+                            'add_error_key'   => true
+                          },
+            'fields'   => {
+                            'log_type'    => 'uitdatabank::search_api::app',
+                            'environment' => 'acceptance'
+                          }
           ) }
 
           it { is_expected.to contain_filebeat__input('foo.example.com_uitdatabank::search_api::app').that_requires('Class[profiles::filebeat]') }
@@ -91,12 +96,17 @@ describe 'profiles::uitdatabank::search_api::logging' do
           it { is_expected.to contain_filebeat__input('bar.example.com_uitdatabank::search_api::access').that_requires('Class[profiles::filebeat]') }
 
           it { is_expected.to contain_filebeat__input('bar.example.com_uitdatabank::search_api::app').with(
-            'input_type' => 'docker',
-            'doc_type'   => 'log',
-            'fields'     => {
-                              'log_type'    => 'uitdatabank::search_api::app',
-                              'environment' => 'production'
-                            }
+            'paths'    => ['/var/lib/docker/containers/*/*-json.log'],
+            'doc_type' => 'log',
+            'json'     => {
+                            'keys_under_root' => true,
+                            'message_key'     => 'log',
+                            'add_error_key'   => true
+                          },
+            'fields'   => {
+                            'log_type'    => 'uitdatabank::search_api::app',
+                            'environment' => 'production'
+                          }
           ) }
 
           it { is_expected.to contain_filebeat__input('bar.example.com_uitdatabank::search_api::app').that_requires('Class[profiles::filebeat]') }


### PR DESCRIPTION
Use the generic log input type instead of docker, which is not supported in the filebeat version we're using
### Added

-

### Changed

-

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
