### PR TITLE
We do not need to remove the undef values, in fact it breaks things on MySQL 8.4 if we do

### DIFF
--- a/manifests/mysql/server.pp
+++ b/manifests/mysql/server.pp
@@ -43,7 +43,7 @@ class profiles::mysql::server (
                                      'long_query_time'                => "${long_query_time}",
                                      'transaction_isolation'          => $transaction_isolation,
                                      'event_scheduler'                => $event_scheduler
-                                   }.delete_undef_values
+                                   }
                      }
 
   include profiles::firewall::rules

--- a/spec/classes/mysql/server_spec.rb
+++ b/spec/classes/mysql/server_spec.rb
@@ -65,6 +65,7 @@ describe 'profiles::mysql::server' do
                                     'mysqld' => {
                                                   'character-set-client-handshake' => 'false',
                                                   'ssl'                            => 'false',
+                                                  'mysql_native_password'          => nil,
                                                   'character-set-server'           => 'utf8mb4',
                                                   'collation-server'               => 'utf8mb4_unicode_ci',
                                                   'bind-address'                   => '127.0.0.1',
@@ -192,6 +193,7 @@ describe 'profiles::mysql::server' do
                                         'mysqld' => {
                                                       'character-set-client-handshake' => 'false',
                                                       'ssl'                            => 'false',
+                                                      'mysql_native_password'          => nil,
                                                       'character-set-server'           => 'utf8mb4',
                                                       'collation-server'               => 'utf8mb4_unicode_ci',
                                                       'bind-address'                   => '0.0.0.0',


### PR DESCRIPTION
Setting a value of a config parameter of mysqld to `undef` removes that parameter from the config if it exists there, which is what we want.