### PR TITLE
[OPS-1550_15]: fix docker_image_tag not updating after deployment

### DIFF
--- a/lib/facter/docker_image_tag.rb
+++ b/lib/facter/docker_image_tag.rb
@@ -3,6 +3,12 @@ Facter.add('docker_image_tag') do
     repos = Facter.value('docker_ecr_repos')
     next nil unless repos.is_a?(Hash) && !repos.empty?
 
+    # Pipeline version tags are stamped as yyyy.MM.dd.HHmmss (see util.pipelineVersion()
+    # in jenkins-global-library). Matching this shape lets us pick the immutable release
+    # tag deterministically, rather than an arbitrary "other" tag on the same image
+    # (which could just as easily resolve to 'latest').
+    version_tag_pattern = /\A\d{4}\.\d{2}\.\d{2}\.\d{6}\z/
+
     repos.each_with_object({}) do |(name, config), result|
       region    = config['region']    || 'eu-west-1'
       image_tag = config['image_tag'] || 'latest'
@@ -12,13 +18,16 @@ Facter.add('docker_image_tag') do
           --repository-name #{name} \
           --image-ids imageTag=#{image_tag} \
           --region #{region} \
-          --query \"imageDetails[0].imageTags[?!= '#{image_tag}'] | [0]\" \
+          --query \"imageDetails[0].imageTags\" \
           --output text",
         on_fail: nil
       )
 
-      tag = output&.strip
-      result[name] = tag unless tag.nil? || tag.empty? || tag == 'None'
+      tags = output.to_s.strip.split(/\s+/)
+      version_tag = tags.find { |tag| tag =~ version_tag_pattern }
+
+      # Fall back to the environment's own floating tag (e.g. 'acceptance')
+      result[name] = version_tag || image_tag
     end
   end
 end

--- a/spec/unit/facter/docker_image_tag_spec.rb
+++ b/spec/unit/facter/docker_image_tag_spec.rb
@@ -1,0 +1,82 @@
+describe Facter::Util::Fact do
+  before(:each) { Facter.clear }
+
+  describe 'docker_image_tag' do
+    context 'when the promoted image carries a pipeline-version tag alongside latest and the environment tag' do
+      before :each do
+        allow(Facter).to receive(:value).with('docker_ecr_repos').and_return(
+          { 'uitdatabank/search-api' => { 'region' => 'eu-west-1', 'image_tag' => 'acceptance' } }
+        )
+        expect(Facter::Core::Execution).to receive(:execute)
+          .with(a_string_matching(%r{--repository-name uitdatabank/search-api}), on_fail: nil)
+          .and_return("acceptance\tlatest\t2026.08.04.120705")
+      end
+
+      it 'picks the pipeline-version tag rather than latest or the environment tag' do
+        expect(Facter.fact('docker_image_tag').value).to eq(
+          { 'uitdatabank/search-api' => '2026.08.04.120705' }
+        )
+      end
+    end
+
+    context 'when no tag on the image matches the pipeline-version shape' do
+      before :each do
+        allow(Facter).to receive(:value).with('docker_ecr_repos').and_return(
+          { 'uitdatabank/search-api' => { 'region' => 'eu-west-1', 'image_tag' => 'acceptance' } }
+        )
+        expect(Facter::Core::Execution).to receive(:execute)
+          .with(a_string_matching(%r{--repository-name uitdatabank/search-api}), on_fail: nil)
+          .and_return("acceptance\tlatest")
+      end
+
+      it 'falls back to the environment tag rather than the global latest default' do
+        expect(Facter.fact('docker_image_tag').value).to eq(
+          { 'uitdatabank/search-api' => 'acceptance' }
+        )
+      end
+    end
+
+    context 'when the aws cli call fails' do
+      before :each do
+        allow(Facter).to receive(:value).with('docker_ecr_repos').and_return(
+          { 'uitdatabank/search-api' => { 'region' => 'eu-west-1', 'image_tag' => 'acceptance' } }
+        )
+        expect(Facter::Core::Execution).to receive(:execute)
+          .with(a_string_matching(%r{--repository-name uitdatabank/search-api}), on_fail: nil)
+          .and_return(nil)
+      end
+
+      it 'falls back to the environment tag rather than the global latest default' do
+        expect(Facter.fact('docker_image_tag').value).to eq(
+          { 'uitdatabank/search-api' => 'acceptance' }
+        )
+      end
+    end
+
+    context 'with multiple repos, each resolving their own pipeline-version tag' do
+      before :each do
+        allow(Facter).to receive(:value).with('docker_ecr_repos').and_return(
+          {
+            'uitdatabank/search-api' => { 'region' => 'eu-west-1', 'image_tag' => 'acceptance' },
+            'uitdatabank/entry-api'  => { 'region' => 'eu-west-1', 'image_tag' => 'acceptance' }
+          }
+        )
+        expect(Facter::Core::Execution).to receive(:execute)
+          .with(a_string_matching(%r{--repository-name uitdatabank/search-api}), on_fail: nil)
+          .and_return("acceptance\tlatest\t2026.08.04.120705")
+        expect(Facter::Core::Execution).to receive(:execute)
+          .with(a_string_matching(%r{--repository-name uitdatabank/entry-api}), on_fail: nil)
+          .and_return("acceptance\t2026.08.03.101500\tlatest")
+      end
+
+      it 'resolves the pipeline-version tag independently per repo' do
+        expect(Facter.fact('docker_image_tag').value).to eq(
+          {
+            'uitdatabank/search-api' => '2026.08.04.120705',
+            'uitdatabank/entry-api'  => '2026.08.03.101500'
+          }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `docker_image_tag` was always resolving to the environment tag, which is immutable, so the deployments weren't triggering a puppet update
### Added

-

### Changed

-

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
